### PR TITLE
Avoid repeated lazy imports in address utilities

### DIFF
--- a/multiaddr/codec.py
+++ b/multiaddr/codec.py
@@ -60,9 +60,19 @@ def bytes_to_string(buf):
     return '/'.join(st)
 
 
+int_to_hex = None
+encode_big_endian_16 = None
+
+
 def address_string_to_bytes(proto, addr_string):
-    from .util import int_to_hex
-    from .util import encode_big_endian_16
+    global int_to_hex
+    if int_to_hex is None:
+        from .util import int_to_hex
+
+    global encode_big_endian_16
+    if encode_big_endian_16 is None:
+        from .util import encode_big_endian_16
+
     if proto.code == P_IP4:  # ipv4
         try:
             ip = IPAddress(addr_string)
@@ -143,8 +153,13 @@ def address_string_to_bytes(proto, addr_string):
         raise ValueError("failed to parse %s addr: unknown" % proto.name)
 
 
+decode_big_endian_16 = None
+
+
 def address_bytes_to_string(proto, buf):
-    from .util import decode_big_endian_16
+    global decode_big_endian_16
+    if decode_big_endian_16 is None:
+        from .util import decode_big_endian_16
     if proto.code == P_IP4:
         return str(IPAddress(int(buf, 16), 4).ipv4())
     elif proto.code == P_IP6:


### PR DESCRIPTION
I verified 5 different runs of the Jupyter kernel and the microbenchmarks were always in the same ballpark.

**Lazy import on every function invocation (status quo)**

```
%timeit address_string_to_bytes(_names_to_protocols['ip4'], '10.11.12.13')

~9.91 µs (mean ± std. dev. of 7 runs, 100000 loops each)
```

**Import moved to the top level**

Since the original intent of the import was lazy, I just put this for demonstration purposes.

```py
from .util import int_to_hex
from .util import encode_big_endian_16

def address_string_to_bytes_v2(proto, addr_string):
    if proto.code == P_IP4:  # ipv4
        try:
            ip = IPAddress(addr_string)
            if ip.version != 4:
```

```
%timeit address_string_to_bytes_v2(_names_to_protocols['ip4'], '10.11.12.13')

~5.48 µs (mean ± std. dev. of 7 runs, 100000 loops each)
```

**Lazy import with a global**

This is the recommendation for lazy imports from the performance wiki referenced below.

```py
int_to_hex = None
encode_big_endian_16 = None

def address_string_to_bytes_v3(proto, addr_string):
    global int_to_hex
    if int_to_hex is None:
        from multiaddr.util import int_to_hex
    
    global encode_big_endian_16
    if encode_big_endian_16 is None:
        from multiaddr.util import encode_big_endian_16
```

```
%timeit address_string_to_bytes_v3(_names_to_protocols['ip4'], '10.11.12.13')

~6.25 µs (mean ± std. dev. of 7 runs, 100000 loops each)
```

**Rationale**

https://wiki.python.org/moin/PythonSpeed/PerformanceTips#Import_Statement_Overhead

![pythonspeed performancetips python wiki](https://user-images.githubusercontent.com/6547711/47682684-f91b3300-dbab-11e8-997b-736122977275.png)



