### PR TITLE
Remove the `code` checks in `Protocol.__init__`

### DIFF
--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -85,9 +85,6 @@ class Protocol(object):
         if not isinstance(vcode, six.binary_type):
             raise ValueError("vcode must be binary")
 
-        if code not in _CODES and code != 0:
-            raise ValueError("Invalid code '%d'" % code)
-
         if size < -1 or size > 128:
             raise ValueError("Invalid size")
         self.code = code

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 
-bumpversion==0.5.3
-wheel==0.29.0
-watchdog==0.8.3
-flake8==2.5.4
-tox==2.3.1
-coverage==4.0.3
-Sphinx==1.3.6
+bumpversion
+wheel
+watchdog
+flake8
+tox
+coverage
+Sphinx
 pytest
 pytest-cov

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -30,7 +30,7 @@ def test_valid(valid_params):
         assert getattr(proto, key) == valid_params[key]
 
 
-@pytest.mark.parametrize("invalid_code", [123, 'abc'])
+@pytest.mark.parametrize("invalid_code", [0.5, 'abc'])
 def test_invalid_code(valid_params, invalid_code):
     assert invalid_code not in protocols._CODES
     valid_params['code'] = invalid_code


### PR DESCRIPTION
Align with the usage of `AddProtocol` in [go-libp2p-circuit](https://github.com/libp2p/go-libp2p-circuit/blob/884b8458e1ba6ec055735125be494a710bb6d2b8/transport.go#L13-L24). No check on `code` is performed when initializing `Protocol`. IMO
- `code not in _CODES` is unnecessary, since it prevents new protocols from being added dynamically, unless you modify `_CODES`
- `code != 0`: I'm not sure of its purpose, but it is not checked in `go-multiaddr`

related discussion: https://github.com/multiformats/go-multiaddr/pull/53