### PR TITLE
Fix used by py-libp2p

### DIFF
--- a/multiaddr/codec.py
+++ b/multiaddr/codec.py
@@ -163,7 +163,7 @@ def address_bytes_to_string(proto, buf):
         buf = buf[num_bytes_read:]
         if len(buf) != size:
             raise ValueError("inconsistent lengths")
-        return base58.b58encode(buf)
+        return base58.b58encode(buf).decode()
     raise ValueError("unknown protocol")
 
 

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -29,19 +29,18 @@ class Multiaddr(object):
     Multiaddr objects are immutable, so `encapsulate` and `decapsulate`
     return new objects rather than modify internal state.
     """
-    def __init__(self, string_addr=None, bytes_addr=None):
+
+    def __init__(self, addr):
         """Instantiate a new Multiaddr.
 
         Args:
-            string_addr (optional): A string-encoded Multiaddr
-            bytes_addr (optional): A byte-encoded Multiaddr
+            addr : A string-encoded or a byte-encoded Multiaddr
 
-        Only one of string_addr or bytes_addr may be set
         """
-        if string_addr is not None and bytes_addr is None:
-            self._bytes = string_to_bytes(string_addr)
-        elif bytes_addr is not None and string_addr is None:
-            self._bytes = bytes_addr
+        if isinstance(addr, str):
+            self._bytes = string_to_bytes(addr)
+        elif isinstance(addr, bytes):
+            self._bytes = addr
         else:
             raise ValueError("Invalid address type, must be bytes or str")
 
@@ -91,7 +90,7 @@ class Multiaddr(object):
         """
         mb = self.to_bytes()
         ob = other.to_bytes()
-        return Multiaddr(bytes_addr=b''.join([mb, ob]))
+        return Multiaddr(b''.join([mb, ob]))
 
     def decapsulate(self, other):
         """Remove a Multiaddr wrapping.

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -5,6 +5,7 @@ from copy import copy
 from .codec import size_for_addr
 from .codec import string_to_bytes
 from .codec import bytes_to_string
+from .codec import protocol_with_name
 from .protocols import protocol_with_code
 from .protocols import read_varint_code
 
@@ -115,6 +116,11 @@ class Multiaddr(object):
     def value_for_protocol(self, code):
         """Return the value (if any) following the specified protocol."""
         from .util import split
+
+        if isinstance(code, str):
+            protocol = protocol_with_name(code)
+            code = protocol.code
+
         for sub_addr in split(self):
             if sub_addr.protocols()[0].code == code:
                 addr_parts = str(sub_addr).split("/")

--- a/multiaddr/protocols.csv
+++ b/multiaddr/protocols.csv
@@ -1,13 +1,27 @@
-code	size	name
-4	32	ip4
-6	16	tcp
-17	16	udp
-33	16	dccp
-41	128	ip6
-132	16	sctp
-301	0	udt
-302	0	utp
-421	V	ipfs
-480	0	http
-443	0	https
-444	10	onion
+code,	size,	name,		comment
+4,	32,	ip4,
+6,	16,	tcp,
+17,	16,	udp,
+33,	16,	dccp,
+41,	128,	ip6,
+42,	V,	ip6zone,	rfc4007 IPv6 zone
+53,	V,	dns,		reserved
+54,	V,	dns4,
+55,	V,	dns6,
+56,	V,	dnsaddr,
+132,	16,	sctp,
+301,	0,	udt,
+302,	0,	utp,
+400,	V,	unix,
+421,	V,	p2p,		preferred over /ipfs
+421,	V,	ipfs,		backwards compatibility; equivalent to /p2p
+444,	96,	onion,
+460,	0,	quic,
+480,	0,	http,
+443,	0,	https,
+477,	0,	ws,
+478,	0,	wss,
+479,	0,	p2p-websocket-star,
+275,	0,	p2p-webrtc-star,
+276,	0,	p2p-webrtc-direct,
+290,	0,	p2p-circuit,

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -12,13 +12,27 @@ P_TCP = 6
 P_UDP = 17
 P_DCCP = 33
 P_IP6 = 41
+P_IP6ZONE = 42  # rfc4007 IPv6 zone
+P_DNS = 53		# reserved
+P_DNS4 = 54
+P_DNS6 = 55
+P_DNSADDR = 56
 P_SCTP = 132
-P_UTP = 301
-P_UDT = 302
-P_IPFS = 421
+P_UDT = 301
+P_UTP = 302
+P_UNIX = 400
+P_P2P = 421		# preferred over /ipfs
+P_IPFS = 421  # backwards compatibility; equivalent to /p2p
+P_ONION = 444
+P_QUIC = 460
 P_HTTP = 480
 P_HTTPS = 443
-P_ONION = 444
+P_WS = 477
+P_WSS = 478
+P_P2P_WEBSOCKET_STAR = 479
+P_P2P_WEBRTC_STAR = 275
+P_P2P_WEBRTC_DIRECT = 276
+P_P2P_CIRCUIT = 290
 
 _CODES = [
     P_IP4,
@@ -26,13 +40,27 @@ _CODES = [
     P_UDP,
     P_DCCP,
     P_IP6,
+    P_IP6ZONE,
+    P_DNS,
+    P_DNS4,
+    P_DNS6,
+    P_DNSADDR,
     P_SCTP,
-    P_UTP,
     P_UDT,
+    P_UTP,
+    P_UNIX,
+    P_P2P,
     P_IPFS,
+    P_ONION,
+    P_QUIC,
     P_HTTP,
     P_HTTPS,
-    P_ONION,
+    P_WS,
+    P_WSS,
+    P_P2P_WEBSOCKET_STAR,
+    P_P2P_WEBRTC_STAR,
+    P_P2P_WEBRTC_DIRECT,
+    P_P2P_CIRCUIT,
 ]
 
 
@@ -70,18 +98,18 @@ class Protocol(object):
 
     def __eq__(self, other):
         return all((self.code == other.code,
-                   self.size == other.size,
-                   self.name == other.name,
-                   self.vcode == other.vcode))
+                    self.size == other.size,
+                    self.name == other.name,
+                    self.vcode == other.vcode))
 
     def __ne__(self, other):
         return not (self == other)
 
     def __repr__(self):
         return "Protocol(code={code}, name='{name}', size={size})".format(
-                code=self.code,
-                size=self.size,
-                name=self.name)
+            code=self.code,
+            size=self.size,
+            name=self.name)
 
 
 def code_to_varint(num):
@@ -118,21 +146,32 @@ def read_varint_code(buf):
 
 # Protocols is the list of multiaddr protocols supported by this module.
 PROTOCOLS = [
-    Protocol(P_IP4, 32, "ip4", code_to_varint(P_IP4)),
-    Protocol(P_TCP, 16, "tcp", code_to_varint(P_TCP)),
-    Protocol(P_UDP, 16, "udp", code_to_varint(P_UDP)),
-    Protocol(P_DCCP, 16, "dccp", code_to_varint(P_DCCP)),
-    Protocol(P_IP6, 128, "ip6", code_to_varint(P_IP6)),
-    # these require varint:
-    Protocol(P_SCTP, 16, "sctp", code_to_varint(P_SCTP)),
-    # Bug in spec? Onion addresses actually need to be 96 bits to account for
-    # the port number.
-    Protocol(P_ONION, 96, "onion", code_to_varint(P_ONION)),
-    Protocol(P_UTP, 0, "utp", code_to_varint(P_UTP)),
-    Protocol(P_UDT, 0, "udt", code_to_varint(P_UDT)),
-    Protocol(P_HTTP, 0, "http", code_to_varint(P_HTTP)),
-    Protocol(P_HTTPS, 0, "https", code_to_varint(P_HTTPS)),
-    Protocol(P_IPFS, LENGTH_PREFIXED_VAR_SIZE, "ipfs", code_to_varint(P_IPFS)),
+    Protocol(P_IP4, 32, 'ip4', code_to_varint(P_IP4)),
+    Protocol(P_TCP, 16, 'tcp', code_to_varint(P_TCP)),
+    Protocol(P_UDP, 16, 'udp', code_to_varint(P_UDP)),
+    Protocol(P_DCCP, 16, 'dccp', code_to_varint(P_DCCP)),
+    Protocol(P_IP6, 128, 'ip6', code_to_varint(P_IP6)),
+    Protocol(P_IP6ZONE,	LENGTH_PREFIXED_VAR_SIZE, 'ip6zone', code_to_varint(P_IP6ZONE)),
+    Protocol(P_DNS, LENGTH_PREFIXED_VAR_SIZE, 'dns', code_to_varint(P_DNS)),
+    Protocol(P_DNS4, LENGTH_PREFIXED_VAR_SIZE, 'dns4', code_to_varint(P_DNS4)),
+    Protocol(P_DNS6, LENGTH_PREFIXED_VAR_SIZE, 'dns6', code_to_varint(P_DNS6)),
+    Protocol(P_DNSADDR,	LENGTH_PREFIXED_VAR_SIZE, 'dnsaddr', code_to_varint(P_DNSADDR)),
+    Protocol(P_SCTP, 16, 'sctp', code_to_varint(P_SCTP)),
+    Protocol(P_UDT, 0, 'udt', code_to_varint(P_UDT)),
+    Protocol(P_UTP, 0, 'utp', code_to_varint(P_UTP)),
+    Protocol(P_UNIX, LENGTH_PREFIXED_VAR_SIZE, 'unix', code_to_varint(P_UNIX)),
+    Protocol(P_P2P,	LENGTH_PREFIXED_VAR_SIZE, 'p2p', code_to_varint(P_P2P)),
+    Protocol(P_IPFS, LENGTH_PREFIXED_VAR_SIZE, 'ipfs', code_to_varint(P_IPFS)),
+    Protocol(P_ONION, 96, 'onion', code_to_varint(P_ONION)),
+    Protocol(P_QUIC, 0, 'quic', code_to_varint(P_QUIC)),
+    Protocol(P_HTTP, 0, 'http', code_to_varint(P_HTTP)),
+    Protocol(P_HTTPS, 0, 'https', code_to_varint(P_HTTPS)),
+    Protocol(P_WS, 0, 'ws', code_to_varint(P_WS)),
+    Protocol(P_WSS, 0, 'wss', code_to_varint(P_WSS)),
+    Protocol(P_P2P_WEBSOCKET_STAR, 0, 'p2p-websocket-star', code_to_varint(P_P2P_WEBSOCKET_STAR)),
+    Protocol(P_P2P_WEBRTC_STAR, 0, 'p2p-webrtc-star', code_to_varint(P_P2P_WEBRTC_STAR)),
+    Protocol(P_P2P_WEBRTC_DIRECT, 0, 'p2p-webrtc-direct', code_to_varint(P_P2P_WEBRTC_DIRECT)),
+    Protocol(P_P2P_CIRCUIT, 0, 'p2p-circuit', code_to_varint(P_P2P_CIRCUIT)),
 ]
 
 _names_to_protocols = dict((proto.name, proto) for proto in PROTOCOLS)

--- a/multiaddr/util.py
+++ b/multiaddr/util.py
@@ -11,7 +11,7 @@ def split(ma):
     addrs = []
     bb = bytes_split(ma.to_bytes())
     for addr in bb:
-        addrs.append(Multiaddr(bytes_addr=binascii.hexlify(addr)))
+        addrs.append(Multiaddr(binascii.hexlify(addr)))
     return addrs
 
 
@@ -19,7 +19,7 @@ def join(multiaddrs):
     bs = []
     for ma in multiaddrs:
         bs.append(ma.to_bytes())
-    return Multiaddr(bytes_addr=b''.join(bs))
+    return Multiaddr(b''.join(bs))
 
 
 def int_to_hex(i, size):

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -209,13 +209,18 @@ def test_get_value():
 
 
 def test_bad_initialization_no_params():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Multiaddr()
 
 
 def test_bad_initialization_too_many_params():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Multiaddr("/ip4/0.0.0.0", "")
+
+
+def test_bad_initialization_wrong_type():
+    with pytest.raises(ValueError):
+        Multiaddr(42)
 
 
 def test_get_value_too_many_fields_protocol(monkeypatch):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -127,8 +127,8 @@ def patch_protocols(monkeypatch):
     monkeypatch.setattr(protocols, '_codes_to_protocols', {})
 
 
-def test_add_protocol(patch_protocols):
-    proto = protocols.Protocol(**valid_params())
+def test_add_protocol(patch_protocols, valid_params):
+    proto = protocols.Protocol(**valid_params)
     protocols.add_protocol(proto)
     assert protocols.PROTOCOLS == [proto]
     assert proto.name in protocols._names_to_protocols
@@ -137,8 +137,8 @@ def test_add_protocol(patch_protocols):
         protocols.P_TCP, 16, "tcp", protocols.code_to_varint(protocols.P_TCP))
 
 
-def test_add_protocol_twice(patch_protocols):
-    proto = protocols.Protocol(**valid_params())
+def test_add_protocol_twice(patch_protocols, valid_params):
+    proto = protocols.Protocol(**valid_params)
     protocols.add_protocol(proto)
     with pytest.raises(ValueError):
         protocols.add_protocol(proto)


### PR DESCRIPTION
As explained in this issue: https://github.com/zixuanzh/py-libp2p/issues/65#issuecomment-440395630
I fork this repo and did a bunch of fixed in order to be able to use it in py-libp2p.
Now that this repo has been moved to the multiformats organization we want to merge these change here so py-libp2p can depend on this repo instead of my fork.