### PR TITLE
Add support for UNIX protocol

### DIFF
--- a/multiaddr/codec.py
+++ b/multiaddr/codec.py
@@ -1,7 +1,6 @@
 import base58
 import base64
 import binascii
-import six
 
 from netaddr import IPAddress
 

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -2,6 +2,7 @@
 import binascii
 from copy import copy
 
+from .codec import address_bytes_to_string
 from .codec import size_for_addr
 from .codec import string_to_bytes
 from .codec import bytes_to_string
@@ -117,14 +118,17 @@ class Multiaddr(object):
         """Return the value (if any) following the specified protocol."""
         from .util import split
 
-        if isinstance(code, str):
-            protocol = protocol_with_name(code)
-            code = protocol.code
+        if not isinstance(code, int):
+            raise ValueError("code type should be `int`, code={}".format(code))
 
         for sub_addr in split(self):
-            if sub_addr.protocols()[0].code == code:
+            protocol = sub_addr.protocols()[0]
+            if protocol.code == code:
+                # e.g. if `sub_addr=/unix/123`, then `addr_parts=['', 'unix', '123']`
                 addr_parts = str(sub_addr).split("/")
                 if len(addr_parts) > 3:
+                    if protocol.path:
+                        return "/" + "/".join(addr_parts[2:])
                     raise ValueError("Unknown Protocol format")
                 elif len(addr_parts) == 3:
                     # If we have an address, return it

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -2,11 +2,9 @@
 import binascii
 from copy import copy
 
-from .codec import address_bytes_to_string
 from .codec import size_for_addr
 from .codec import string_to_bytes
 from .codec import bytes_to_string
-from .codec import protocol_with_name
 from .protocols import protocol_with_code
 from .protocols import read_varint_code
 

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -124,9 +124,9 @@ class Multiaddr(object):
             if protocol.code == code:
                 # e.g. if `sub_addr=/unix/123`, then `addr_parts=['', 'unix', '123']`
                 addr_parts = str(sub_addr).split("/")
+                if protocol.path:
+                    return "/" + "/".join(addr_parts[2:])
                 if len(addr_parts) > 3:
-                    if protocol.path:
-                        return "/" + "/".join(addr_parts[2:])
                     raise ValueError("Unknown Protocol format")
                 elif len(addr_parts) == 3:
                     # If we have an address, return it

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -86,7 +86,7 @@ class Protocol(object):
         if not isinstance(vcode, six.binary_type):
             raise ValueError("vcode must be binary")
         if not isinstance(path, bool):
-            raise ValueError("path must be binary")
+            raise ValueError("path must be a boolean")
 
         if code not in _CODES and code != 0:
             raise ValueError("Invalid code '%d'" % code)
@@ -151,7 +151,6 @@ def read_varint_code(buf):
 
 
 # Protocols is the list of multiaddr protocols supported by this module.
-# TODO: might change it to more readable?
 PROTOCOLS = [
     Protocol(P_IP4, 32, 'ip4', code_to_varint(P_IP4)),
     Protocol(P_TCP, 16, 'tcp', code_to_varint(P_TCP)),

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -73,9 +73,10 @@ class Protocol(object):
         "size",   # int (-1 indicates a length-prefixed variable size)
         "name",   # string
         "vcode",  # bytes
+        "path",   # bool (True indicates a path protocol (eg unix, http))
     ]
 
-    def __init__(self, code, size, name, vcode):
+    def __init__(self, code, size, name, vcode, path=False):
         if not isinstance(code, six.integer_types):
             raise ValueError("code must be an integer")
         if not isinstance(size, six.integer_types):
@@ -84,6 +85,8 @@ class Protocol(object):
             raise ValueError("name must be a string")
         if not isinstance(vcode, six.binary_type):
             raise ValueError("vcode must be binary")
+        if not isinstance(path, bool):
+            raise ValueError("path must be binary")
 
         if code not in _CODES and code != 0:
             raise ValueError("Invalid code '%d'" % code)
@@ -94,21 +97,25 @@ class Protocol(object):
         self.size = size
         self.name = name
         self.vcode = vcode
+        self.path = path
 
     def __eq__(self, other):
         return all((self.code == other.code,
                     self.size == other.size,
                     self.name == other.name,
-                    self.vcode == other.vcode))
+                    self.vcode == other.vcode,
+                    self.path == other.path))
 
     def __ne__(self, other):
         return not self == other
 
     def __repr__(self):
-        return "Protocol(code={code}, name='{name}', size={size})".format(
+        return "Protocol(code={code}, name='{name}', size={size}, path={path})".format(
             code=self.code,
             size=self.size,
-            name=self.name)
+            name=self.name,
+            path=self.path,
+        )
 
 
 def code_to_varint(num):
@@ -144,6 +151,7 @@ def read_varint_code(buf):
 
 
 # Protocols is the list of multiaddr protocols supported by this module.
+# TODO: might change it to more readable?
 PROTOCOLS = [
     Protocol(P_IP4, 32, 'ip4', code_to_varint(P_IP4)),
     Protocol(P_TCP, 16, 'tcp', code_to_varint(P_TCP)),
@@ -169,7 +177,7 @@ PROTOCOLS = [
     Protocol(P_P2P_WEBRTC_STAR, 0, 'p2p-webrtc-star', code_to_varint(P_P2P_WEBRTC_STAR)),
     Protocol(P_P2P_WEBRTC_DIRECT, 0, 'p2p-webrtc-direct', code_to_varint(P_P2P_WEBRTC_DIRECT)),
     Protocol(P_P2P_CIRCUIT, 0, 'p2p-circuit', code_to_varint(P_P2P_CIRCUIT)),
-    Protocol(P_UNIX, LENGTH_PREFIXED_VAR_SIZE, 'unix', code_to_varint(P_UNIX)),
+    Protocol(P_UNIX, LENGTH_PREFIXED_VAR_SIZE, 'unix', code_to_varint(P_UNIX), path=True),
 ]
 
 _names_to_protocols = dict((proto.name, proto) for proto in PROTOCOLS)

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -51,7 +51,7 @@ def test_size_for_addr(proto, buf, expected):
       b'\x06\x10\xe1']),
 ])
 def test_bytes_split(buf, expected):
-    assert  bytes_split(buf) == expected
+    assert bytes_split(buf) == expected
 
 
 @pytest.mark.parametrize("proto, buf, expected", ADDR_BYTES_MAP_STR_TEST_DATA)
@@ -85,11 +85,12 @@ def test_string_to_bytes_value_error(string):
 
 
 class DummyProtocol(Protocol):
-    def __init__(self, code, size, name, vcode):
+    def __init__(self, code, size, name, vcode, path=False):
         self.code = code
         self.size = size
         self.name = name
         self.vcode = vcode
+        self.path = path
 
 
 @pytest.mark.parametrize("proto, address", [

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -216,6 +216,9 @@ def test_get_value():
     assert_value_for_proto(a, P_IP4, "0.0.0.0")
     assert_value_for_proto(a, P_UNIX, "/a/b/c/d")
 
+    a = Multiaddr("/unix/studio")
+    assert_value_for_proto(a, P_UNIX, "/studio")  # only a path.
+
 
 def test_bad_initialization_no_params():
     with pytest.raises(TypeError):

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -12,6 +12,7 @@ from multiaddr.protocols import P_P2P
 from multiaddr.protocols import P_UTP
 from multiaddr.protocols import P_TCP
 from multiaddr.protocols import P_UDP
+from multiaddr.protocols import P_UNIX
 from multiaddr.util import split
 from multiaddr.util import join
 
@@ -41,7 +42,10 @@ from multiaddr.util import join
      "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa",
      "/ip4/127.0.0.1/tcp",
      "/ip4/127.0.0.1/p2p",
-     "/ip4/127.0.0.1/p2p/tcp"])
+     "/ip4/127.0.0.1/p2p/tcp",
+     "/unix",
+     "/ip4/1.2.3.4/tcp/80/unix",
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",])
 def test_invalid(addr_str):
     with pytest.raises(ValueError):
         Multiaddr(addr_str)
@@ -71,11 +75,12 @@ def test_invalid(addr_str):
      "/tcp/1234/https",
      "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
      "/ip4/127.0.0.1/udp/1234",
-     "/ip4/127.0.0.1/udp/0",
-     "/ip4/127.0.0.1/tcp/1234",
-     "/ip4/127.0.0.1/tcp/1234/",
-     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234"])  # nopep8
+     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+     "/unix/a/b/c/d/e",
+     "/unix/stdio",
+     "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
+     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",])  # nopep8
 def test_valid(addr_str):
     ma = Multiaddr(addr_str)
     assert str(ma) == addr_str.rstrip("/")
@@ -207,6 +212,10 @@ def test_get_value():
     assert_value_for_proto(a, P_UDP, "12345")
     assert_value_for_proto(a, P_UTP, "")
 
+    a = Multiaddr("/ip4/0.0.0.0/unix/a/b/c/d")  # ending in a path one.
+    assert_value_for_proto(a, P_IP4, "0.0.0.0")
+    assert_value_for_proto(a, P_UNIX, "/a/b/c/d")
+
 
 def test_bad_initialization_no_params():
     with pytest.raises(TypeError):
@@ -236,6 +245,12 @@ def test_get_value_too_many_fields_protocol(monkeypatch):
     a = Multiaddr("/ip4/127.0.0.1/udp/1234")
     with pytest.raises(ValueError):
         a.value_for_protocol(P_UDP)
+
+
+def test_value_for_protocol_argument_wrong_type():
+    a = Multiaddr("/ip4/127.0.0.1/udp/1234")
+    with pytest.raises(ValueError):
+        a.value_for_protocol('str123')
 
 
 def test_multi_addr_str_corruption():

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -45,7 +45,7 @@ from multiaddr.util import join
      "/ip4/127.0.0.1/p2p/tcp",
      "/unix",
      "/ip4/1.2.3.4/tcp/80/unix",
-     "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",])
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct"])
 def test_invalid(addr_str):
     with pytest.raises(ValueError):
         Multiaddr(addr_str)
@@ -80,7 +80,7 @@ def test_invalid(addr_str):
      "/unix/stdio",
      "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
      "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
-     "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",])  # nopep8
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct"])  # nopep8
 def test_valid(addr_str):
     ma = Multiaddr(addr_str)
     assert str(ma) == addr_str.rstrip("/")

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -21,7 +21,8 @@ def valid_params():
     return {'code': protocols.P_IP4,
             'size': 32,
             'name': 'ipb4',
-            'vcode': protocols.code_to_varint(protocols.P_IP4)}
+            'vcode': protocols.code_to_varint(protocols.P_IP4),
+            'path': False}
 
 
 def test_valid(valid_params):
@@ -55,6 +56,13 @@ def test_invalid_name(valid_params, invalid_name):
 @pytest.mark.parametrize("invalid_vcode", [3, u'a3'])
 def test_invalid_vcode(valid_params, invalid_vcode):
     valid_params['vcode'] = invalid_vcode
+    with pytest.raises(ValueError):
+        protocols.Protocol(**valid_params)
+
+
+@pytest.mark.parametrize("invalid_path", [123, '123', 0.123])
+def test_invalid_path(valid_params, invalid_path):
+    valid_params['path'] = invalid_path
     with pytest.raises(ValueError):
         protocols.Protocol(**valid_params)
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -152,7 +152,7 @@ def test_add_protocol_twice(patch_protocols, valid_params):
 
 def test_protocol_repr():
     proto = protocols.protocol_with_name('ip4')
-    assert "Protocol(code=4, name='ip4', size=32)" == repr(proto)
+    assert "Protocol(code=4, name='ip4', size=32, path=False)" == repr(proto)
 
 
 @pytest.mark.parametrize("buf", [


### PR DESCRIPTION
Current py-multiaddr cannot encode/decode the unix protocol correctly. This PR aims to support it. 
- The test cases are from `go-multiaddr`.
- `Protocol.path` is added referenced from `go-multiaddr`([link](https://github.com/multiformats/go-multiaddr/blob/master/protocol.go#L38)), in order for the code to parse the value correctly.

#### Note
IMO it is worthwhile to introduce [`Component`](https://github.com/multiformats/go-multiaddr/blob/master/component.go#L11) to refactor the codebase. It reduces some redundant parsing for the bytes/string. If it helps to make the code cleaner, I'd like to start on the refactoring after this PR.