### PR TITLE
Allow parsing of DNS names and non-ASCII unix sockets

### DIFF
--- a/multiaddr/codec.py
+++ b/multiaddr/codec.py
@@ -1,6 +1,7 @@
 import base58
 import base64
 import binascii
+import os
 
 import idna
 from netaddr import IPAddress
@@ -160,7 +161,7 @@ def address_string_to_bytes(proto, addr_string):
             raise ValueError("invalid P2P multihash: %s" % mm)
         return b''.join([size, mm])
     elif proto.code == P_UNIX:
-        addr_string_bytes = addr_string.encode("ascii")
+        addr_string_bytes = os.fsencode(addr_string)
         size = code_to_varint(len(addr_string_bytes))
         return b''.join([size, binascii.hexlify(addr_string_bytes)])
     elif proto.code in (P_DNS, P_DNS4, P_DNS6):
@@ -200,7 +201,7 @@ def address_bytes_to_string(proto, buf):
     elif proto.code == P_UNIX:
         buf = binascii.unhexlify(buf)
         size, num_bytes_read = read_varint_code(buf)
-        return buf[num_bytes_read:].decode('ascii')
+        return os.fsdecode(buf[num_bytes_read:])
     elif proto.code in (P_DNS, P_DNS4, P_DNS6):
         buf = binascii.unhexlify(buf)
         size, num_bytes_read = read_varint_code(buf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ varint
 six
 base58
 netaddr
+idna

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -23,6 +23,14 @@ ADDR_BYTES_MAP_STR_TEST_DATA = [
     (_names_to_protocols['p2p'],
      b'221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a68911c0b',
      'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'),
+
+# Additional test data
+    (_names_to_protocols['dns4'],
+     b'30786e2d2d34676272696d2e786e2d2d2d2d796d63626161616a6c6336646a3762786e6532632e786e2d2d776762683163',
+     u'موقع.وزارة-الاتصالات.مصر'),  # Explicietly mark as unicode to force it LTR
+    (_names_to_protocols['dns4'],
+     b'16786e2d2d667562616c6c2d6374612e6578616d706c65',
+     'fußball.example'),  # This will fail if IDNA-2003/NamePrep is used
 ]
 
 BYTES_MAP_STR_TEST_DATA = [

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -45,7 +45,10 @@ from multiaddr.util import join
      "/ip4/127.0.0.1/p2p/tcp",
      "/unix",
      "/ip4/1.2.3.4/tcp/80/unix",
-     "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct"])
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",
+     "/dns",
+     "/dns4",
+     "/dns6"])
 def test_invalid(addr_str):
     with pytest.raises(ValueError):
         Multiaddr(addr_str)
@@ -80,7 +83,9 @@ def test_invalid(addr_str):
      "/unix/stdio",
      "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
      "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
-     "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct"])  # nopep8
+     "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
+     "/dns/example.com",
+     "/dns4/موقع.وزارة-الاتصالات.مصر"])  # nopep8
 def test_valid(addr_str):
     ma = Multiaddr(addr_str)
     assert str(ma) == addr_str.rstrip("/")

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -80,6 +80,7 @@ def test_invalid(addr_str):
      "/ip4/127.0.0.1/udp/1234",
      "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
      "/unix/a/b/c/d/e",
+     "/unix/Überrschung!/大柱",
      "/unix/stdio",
      "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
      "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",


### PR DESCRIPTION
Some Details:

  * Domain names will be encoded using IDNA-2008 for their binary representation – this requires the `idna` library since the Python stdlib `encoding.idna` only supports IDNA-2003 which will produce incompatible results in some cases
  * During encoding domain names will also be lower-cased by the library bringing them into a “canonical” form
  * The Unix Domain Socket paths are encoded and decoded using the `os.fsencode` and `os.fsdecode` making their binary representation system-specific (from the Unicode point of view); since file system paths actually *are* binary paths on Unix however this is technically the more faithful encoding and it also happens to be the way Python itself approaches the problem

I'll probably be back with more patches if this one goes through.

Can I also backport this to Python 2, btw?