### PR TITLE
 Rip out the hex encoding of the binary multiaddr in favour of “really” just storing binary

### DIFF
--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import binascii
 from copy import copy
 
 import six
@@ -90,7 +89,7 @@ class Multiaddr(object):
 
     def protocols(self):
         """Returns a list of Protocols this Multiaddr includes."""
-        buf = binascii.unhexlify(self.to_bytes())
+        buf = self.to_bytes()
         protos = []
         while buf:
             code, num_bytes_read = read_varint_code(buf)

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -118,15 +118,6 @@ class Protocol(object):
         )
 
 
-def code_to_varint(num):
-    """Convert an integer to a varint-encoded byte."""
-    return binascii.hexlify(varint.encode(num))
-
-
-def varint_to_code(buf):
-    return varint.decode_bytes(binascii.unhexlify(buf))
-
-
 def _uvarint(buf):
     """Reads a varint from a bytes buffer and returns the value and # bytes"""
     x = 0
@@ -152,31 +143,31 @@ def read_varint_code(buf):
 
 # Protocols is the list of multiaddr protocols supported by this module.
 PROTOCOLS = [
-    Protocol(P_IP4, 32, 'ip4', code_to_varint(P_IP4)),
-    Protocol(P_TCP, 16, 'tcp', code_to_varint(P_TCP)),
-    Protocol(P_UDP, 16, 'udp', code_to_varint(P_UDP)),
-    Protocol(P_DCCP, 16, 'dccp', code_to_varint(P_DCCP)),
-    Protocol(P_IP6, 128, 'ip6', code_to_varint(P_IP6)),
-    Protocol(P_IP6ZONE,	LENGTH_PREFIXED_VAR_SIZE, 'ip6zone', code_to_varint(P_IP6ZONE)),
-    Protocol(P_DNS, LENGTH_PREFIXED_VAR_SIZE, 'dns', code_to_varint(P_DNS)),
-    Protocol(P_DNS4, LENGTH_PREFIXED_VAR_SIZE, 'dns4', code_to_varint(P_DNS4)),
-    Protocol(P_DNS6, LENGTH_PREFIXED_VAR_SIZE, 'dns6', code_to_varint(P_DNS6)),
-    Protocol(P_DNSADDR,	LENGTH_PREFIXED_VAR_SIZE, 'dnsaddr', code_to_varint(P_DNSADDR)),
-    Protocol(P_SCTP, 16, 'sctp', code_to_varint(P_SCTP)),
-    Protocol(P_UDT, 0, 'udt', code_to_varint(P_UDT)),
-    Protocol(P_UTP, 0, 'utp', code_to_varint(P_UTP)),
-    Protocol(P_P2P, LENGTH_PREFIXED_VAR_SIZE, 'p2p', code_to_varint(P_P2P)),
-    Protocol(P_ONION, 96, 'onion', code_to_varint(P_ONION)),
-    Protocol(P_QUIC, 0, 'quic', code_to_varint(P_QUIC)),
-    Protocol(P_HTTP, 0, 'http', code_to_varint(P_HTTP)),
-    Protocol(P_HTTPS, 0, 'https', code_to_varint(P_HTTPS)),
-    Protocol(P_WS, 0, 'ws', code_to_varint(P_WS)),
-    Protocol(P_WSS, 0, 'wss', code_to_varint(P_WSS)),
-    Protocol(P_P2P_WEBSOCKET_STAR, 0, 'p2p-websocket-star', code_to_varint(P_P2P_WEBSOCKET_STAR)),
-    Protocol(P_P2P_WEBRTC_STAR, 0, 'p2p-webrtc-star', code_to_varint(P_P2P_WEBRTC_STAR)),
-    Protocol(P_P2P_WEBRTC_DIRECT, 0, 'p2p-webrtc-direct', code_to_varint(P_P2P_WEBRTC_DIRECT)),
-    Protocol(P_P2P_CIRCUIT, 0, 'p2p-circuit', code_to_varint(P_P2P_CIRCUIT)),
-    Protocol(P_UNIX, LENGTH_PREFIXED_VAR_SIZE, 'unix', code_to_varint(P_UNIX), path=True),
+    Protocol(P_IP4, 32, 'ip4', varint.encode(P_IP4)),
+    Protocol(P_TCP, 16, 'tcp', varint.encode(P_TCP)),
+    Protocol(P_UDP, 16, 'udp', varint.encode(P_UDP)),
+    Protocol(P_DCCP, 16, 'dccp', varint.encode(P_DCCP)),
+    Protocol(P_IP6, 128, 'ip6', varint.encode(P_IP6)),
+    Protocol(P_IP6ZONE,	LENGTH_PREFIXED_VAR_SIZE, 'ip6zone', varint.encode(P_IP6ZONE)),
+    Protocol(P_DNS, LENGTH_PREFIXED_VAR_SIZE, 'dns', varint.encode(P_DNS)),
+    Protocol(P_DNS4, LENGTH_PREFIXED_VAR_SIZE, 'dns4', varint.encode(P_DNS4)),
+    Protocol(P_DNS6, LENGTH_PREFIXED_VAR_SIZE, 'dns6', varint.encode(P_DNS6)),
+    Protocol(P_DNSADDR,	LENGTH_PREFIXED_VAR_SIZE, 'dnsaddr', varint.encode(P_DNSADDR)),
+    Protocol(P_SCTP, 16, 'sctp', varint.encode(P_SCTP)),
+    Protocol(P_UDT, 0, 'udt', varint.encode(P_UDT)),
+    Protocol(P_UTP, 0, 'utp', varint.encode(P_UTP)),
+    Protocol(P_P2P, LENGTH_PREFIXED_VAR_SIZE, 'p2p', varint.encode(P_P2P)),
+    Protocol(P_ONION, 96, 'onion', varint.encode(P_ONION)),
+    Protocol(P_QUIC, 0, 'quic', varint.encode(P_QUIC)),
+    Protocol(P_HTTP, 0, 'http', varint.encode(P_HTTP)),
+    Protocol(P_HTTPS, 0, 'https', varint.encode(P_HTTPS)),
+    Protocol(P_WS, 0, 'ws', varint.encode(P_WS)),
+    Protocol(P_WSS, 0, 'wss', varint.encode(P_WSS)),
+    Protocol(P_P2P_WEBSOCKET_STAR, 0, 'p2p-websocket-star', varint.encode(P_P2P_WEBSOCKET_STAR)),
+    Protocol(P_P2P_WEBRTC_STAR, 0, 'p2p-webrtc-star', varint.encode(P_P2P_WEBRTC_STAR)),
+    Protocol(P_P2P_WEBRTC_DIRECT, 0, 'p2p-webrtc-direct', varint.encode(P_P2P_WEBRTC_DIRECT)),
+    Protocol(P_P2P_CIRCUIT, 0, 'p2p-circuit', varint.encode(P_P2P_CIRCUIT)),
+    Protocol(P_UNIX, LENGTH_PREFIXED_VAR_SIZE, 'unix', varint.encode(P_UNIX), path=True),
 ]
 
 _names_to_protocols = dict((proto.name, proto) for proto in PROTOCOLS)

--- a/multiaddr/util.py
+++ b/multiaddr/util.py
@@ -29,7 +29,3 @@ else:  # PY2
     def packed_net_bytes_to_int(b):
         """Convert the given big-endian byte-string to an int."""
         return int(b.encode('hex'), 16)
-
-
-def decode_big_endian_16(b):
-	return struct.unpack_from('>H', b.rjust(2, b'\0'))[0]

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -15,30 +15,33 @@ from multiaddr.protocols import Protocol
 # through the go implementation of multiaddr.
 # https://github.com/jbenet/multiaddr
 ADDR_BYTES_MAP_STR_TEST_DATA = [
-    (_names_to_protocols['ip4'], b'0a0b0c0d', '10.11.12.13'),
-    (_names_to_protocols['ip6'], b'1aa12bb23cc34dd45ee56ff67ab78ac8',
+    (_names_to_protocols['ip4'], b'\x0a\x0b\x0c\x0d', '10.11.12.13'),
+    (_names_to_protocols['ip6'],
+     b'\x1a\xa1\x2b\xb2\x3c\xc3\x4d\xd4\x5e\xe5\x6f\xf6\x7a\xb7\x8a\xc8',
      '1aa1:2bb2:3cc3:4dd4:5ee5:6ff6:7ab7:8ac8'),
-    (_names_to_protocols['tcp'], b'abcd', '43981'),
-    (_names_to_protocols['onion'], b'9a18087306369043091f04d2',
+    (_names_to_protocols['tcp'], b'\xab\xcd', '43981'),
+    (_names_to_protocols['onion'],
+     b'\x9a\x18\x08\x73\x06\x36\x90\x43\x09\x1f\x04\xd2',
      'timaq4ygg2iegci7:1234'),
     (_names_to_protocols['p2p'],
-     b'221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a68911c0b',
+     b'\x22\x12\x20\xd5\x2e\xbb\x89\xd8\x5b\x02\xa2\x84\x94\x82\x03\xa6\x2f\xf2'
+     b'\x83\x89\xc5\x7c\x9f\x42\xbe\xec\x4e\xc2\x0d\xb7\x6a\x68\x91\x1c\x0b',
      'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'),
 
 # Additional test data
     (_names_to_protocols['dns4'],
-     b'30786e2d2d34676272696d2e786e2d2d2d2d796d63626161616a6c6336646a3762786e6532632e786e2d2d776762683163',
+     b'\x30xn--4gbrim.xn----ymcbaaajlc6dj7bxne2c.xn--wgbh1c',
      u'موقع.وزارة-الاتصالات.مصر'),  # Explicietly mark this as unicode to force the text to be LTR in editors
     (_names_to_protocols['dns4'],
-     b'16786e2d2d667562616c6c2d6374612e6578616d706c65',
+     b'\x16xn--fuball-cta.example',
      u'fußball.example'),  # This will fail if IDNA-2003/NamePrep is used
 ]
 
 BYTES_MAP_STR_TEST_DATA = [
-    ("/ip4/127.0.0.1/udp/1234", b'047f000001910204d2'),
-    ("/ip4/127.0.0.1/tcp/4321", b'047f0000010610e1'),
+    ("/ip4/127.0.0.1/udp/1234", b'\x04\x7f\x00\x00\x01\x91\x02\x04\xd2'),
+    ("/ip4/127.0.0.1/tcp/4321", b'\x04\x7f\x00\x00\x01\x06\x10\xe1'),
     ("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321",
-     b'047f000001910204d2047f0000010610e1')
+     b'\x04\x7f\x00\x00\x01\x91\x02\x04\xd2\x04\x7f\x00\x00\x01\x06\x10\xe1')
 ]
 
 
@@ -53,7 +56,7 @@ def test_size_for_addr(proto, buf, expected):
 
 @pytest.mark.parametrize("buf, expected", [
     # "/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321"
-    (b'047f000001910204d2047f0000010610e1',
+    (b'\x04\x7f\x00\x00\x01\x91\x02\x04\xd2\x04\x7f\x00\x00\x01\x06\x10\xe1',
      [b'\x04\x7f\x00\x00\x01',
       b'\x91\x02\04\xd2',
       b'\x04\x7f\x00\x00\x01',
@@ -121,9 +124,9 @@ def test_address_string_to_bytes_value_error(proto, address):
 
 
 @pytest.mark.parametrize("proto, buf", [
-    (DummyProtocol(234, 32, 'test', b'123'), b'0a0b0c0d'),
-    (_names_to_protocols['p2p'], b'15230d52ebb89d85b02a284948203a'),
-    (_names_to_protocols['tcp'], b'ffffffff')
+    (DummyProtocol(234, 32, 'test', b'123'), b'\x0a\x0b\x0c\x0d'),
+    (_names_to_protocols['p2p'], b'\x15\x23\x0d\x52\xeb\xb8\x9d\x85\xb0\x2a\x28\x49\x48\x20\x3a'),
+    (_names_to_protocols['tcp'], b'\xff\xff\xff\xff')
 ])
 def test_address_bytes_to_string_value_error(proto, buf):
     with pytest.raises(ValueError):

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -71,6 +71,7 @@ def test_invalid(addr_str):
      "/udp/1234",
      "/tcp/1234",
      "/sctp/1234",
+     "/utp",
      "/udp/65535",
      "/tcp/65535",
      "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,18 +1,19 @@
 from multiaddr import protocols
 import pytest
+import varint
 
 
 def test_code_to_varint():
-    vi = protocols.code_to_varint(5)
-    assert vi == b'05'
-    vi = protocols.code_to_varint(150)
-    assert vi == b'9601'
+    vi = varint.encode(5)
+    assert vi == b'\x05'
+    vi = varint.encode(150)
+    assert vi == b'\x96\x01'
 
 
 def test_varint_to_code():
-    cc = protocols.varint_to_code(b'05')
+    cc = varint.decode_bytes(b'\x05')
     assert cc == 5
-    cc = protocols.varint_to_code(b'9601')
+    cc = varint.decode_bytes(b'\x96\x01')
     assert cc == 150
 
 
@@ -21,7 +22,7 @@ def valid_params():
     return {'code': protocols.P_IP4,
             'size': 32,
             'name': 'ipb4',
-            'vcode': protocols.code_to_varint(protocols.P_IP4),
+            'vcode': varint.encode(protocols.P_IP4),
             'path': False}
 
 
@@ -142,7 +143,7 @@ def test_add_protocol(patch_protocols, valid_params):
     assert proto.name in protocols._names_to_protocols
     assert proto.code in protocols._codes_to_protocols
     proto = protocols.Protocol(
-        protocols.P_TCP, 16, "tcp", protocols.code_to_varint(protocols.P_TCP))
+        protocols.P_TCP, 16, "tcp", varint.encode(protocols.P_TCP))
 
 
 def test_add_protocol_twice(patch_protocols, valid_params):


### PR DESCRIPTION
Depends on #36. Fixes #28.

This is a breaking change in that `Multiaddr.to_bytes()` now returns “just bytes”, rather then “hex-encoded bytes” and the `Multiaddr.__init__` constructor now also treats received bytes objects as “just bytes”.


