### PR TITLE
Miscellaneous improvements

### DIFF
--- a/multiaddr/codecs/_util.py
+++ b/multiaddr/codecs/_util.py
@@ -2,7 +2,7 @@ if hasattr(int, 'from_bytes'):
     def packed_net_bytes_to_int(b):
         """Convert the given big-endian byte-string to an int."""
         return int.from_bytes(b, byteorder='big')
-else:  # PY2
+else:  # pragma: no cover (PY2)
     def packed_net_bytes_to_int(b):
         """Convert the given big-endian byte-string to an int."""
         return int(b.encode('hex'), 16)

--- a/multiaddr/codecs/fspath.py
+++ b/multiaddr/codecs/fspath.py
@@ -13,16 +13,16 @@ IS_PATH = True
 if hasattr(os, "fsencode") and hasattr(os, "fsdecode"):
     fsencode = os.fsencode
     fsdecode = os.fsdecode
-else:  # PY2
+else:  # pragma: no cover (PY2)
     import sys
 
     def fsencode(path):
-        if not isinstance(path, six.binary_type):  # pragma: no cover
+        if not isinstance(path, six.binary_type):
             path = path.encode(sys.getfilesystemencoding())
         return path
 
     def fsdecode(path):
-        if not isinstance(path, six.text_type):  # pragma: no cover
+        if not isinstance(path, six.text_type):
             path = path.decode(sys.getfilesystemencoding())
         return path
 

--- a/multiaddr/codecs/p2p.py
+++ b/multiaddr/codecs/p2p.py
@@ -12,7 +12,7 @@ IS_PATH = False
 
 def to_bytes(proto, string):
     # the address is a base58-encoded string
-    if six.PY2 and isinstance(string, unicode):
+    if six.PY2 and isinstance(string, unicode):  # pragma: no cover (PY2)
         string = string.encode("ascii")
     mm = base58.b58decode(string)
     if len(mm) < 5:

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -188,8 +188,8 @@ class Multiaddr(collections.abc.Mapping):
         For example:
             /ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
         """
-        s1 = str(self)
-        s2 = str(other)
+        s1 = self.to_bytes()
+        s2 = other.to_bytes()
         try:
             idx = s1.rindex(s2)
         except ValueError:

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -110,7 +110,21 @@ class Multiaddr(object):
         return Multiaddr(s1[:idx])
 
     def value_for_protocol(self, proto):
-        """Return the value (if any) following the specified protocol."""
+        """Return the value (if any) following the specified protocol
+        
+        Returns
+        -------
+        union[object, NoneType]
+            The parsed protocol value for the given protocol code or ``None``
+            if the given protocol does not require any value
+        
+        Raises
+        ------
+        ~multiaddr.exceptions.BinaryParseError
+            The stored MultiAddr binary representation is invalid
+        ~multiaddr.exceptions.ProtocolLookupError
+            MultiAddr does not contain any instance of this protocol
+        """
         if not isinstance(proto, protocols.Protocol):
             if isinstance(proto, int):
                 proto = protocols.protocol_with_code(proto)
@@ -129,6 +143,6 @@ class Multiaddr(object):
                         six.raise_from(exceptions.BinaryParseError(str(exc), self.to_bytes(), proto2.name, exc), exc)
                 else:
                     # We were given something like '/utp', which doesn't have
-                    # an address, so return ''
-                    return ''
+                    # an address, so return None
+                    return None
         raise exceptions.ProtocolLookupError(proto, str(self))

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -39,7 +39,7 @@ class Multiaddr(object):
         # On Python 2 text string will often be binary anyways so detect the
         # obvious case of a “binary-encoded” multiaddr starting with a slash
         # and decode it into text
-        if six.PY2 and isinstance(addr, str) and addr.startswith("/"):
+        if six.PY2 and isinstance(addr, str) and addr.startswith("/"):  # pragma: no cover (PY2)
             addr = addr.decode("utf-8")
 
         if isinstance(addr, six.text_type):
@@ -66,7 +66,7 @@ class Multiaddr(object):
     # On Python 2 __str__ needs to return binary text, so expose the original
     # function as __unicode__ and transparently encode its returned text based
     # on the current locale
-    if six.PY2:
+    if six.PY2:  # pragma: no cover (PY2)
         __unicode__ = __str__
 
         def __str__(self):

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -100,13 +100,16 @@ class Protocol(object):
         return varint.encode(self.code)
 
     def __eq__(self, other):
+        if not isinstance(other, Protocol):
+            return NotImplemented
+
         return all((self.code == other.code,
                     self.name == other.name,
                     self.codec == other.codec,
                     self.path == other.path))
 
-    def __ne__(self, other):
-        return not self == other
+    def __hash__(self):
+        return self.code
 
     def __repr__(self):
         return "Protocol(code={code!r}, name={name!r}, codec={codec!r})".format(
@@ -198,6 +201,17 @@ def protocol_with_code(code):
     if code not in _codes_to_protocols:
         raise exceptions.ProtocolNotFoundError(code, "code")
     return _codes_to_protocols[code]
+
+
+def protocol_with_any(proto):
+    if isinstance(proto, Protocol):
+        return proto
+    elif isinstance(proto, int):
+        return protocol_with_code(proto)
+    elif isinstance(proto, six.string_types):
+        return protocol_with_name(proto)
+    else:
+        raise TypeError("Protocol object, name or code expected, got {0!r}".format(proto))
 
 
 def protocols_with_string(string):

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -123,7 +123,7 @@ def _uvarint(buf):
     for i, b_str in enumerate(buf):
         if six.PY3:
             b = b_str
-        else:
+        else:  # pragma: no cover (PY2)
             b = int(binascii.b2a_hex(b_str), 16)
         if b < 0x80:
             if i > 9 or (i == 9 and b > 1):

--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -14,9 +14,6 @@ from .protocols import read_varint_code
 
 
 def string_to_bytes(string):
-    if not string:
-        return b''
-
     bs = []
     for proto, codec, value in string_iter(string):
         bs.append(varint.encode(proto.code))

--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -78,7 +78,7 @@ def string_iter(string):
                 value = "/" + "/".join(sp)
                 if not six.PY2:
                     sp.clear()
-                else:
+                else:  # pragma: no cover (PY2)
                     sp = []
             else:
                 value = sp.pop(0)

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -234,6 +234,34 @@ def test_get_value():
     assert_value_for_proto(a, P_UNIX, "/studio")  # only a path.
 
 
+def test_views():
+    ma = Multiaddr(
+        "/ip4/127.0.0.1/utp/tcp/5555/udp/1234/utp/"
+        "p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
+
+    for idx, (proto1, proto2, item, value) in enumerate(zip(ma, ma.keys(), ma.items(), ma.values())):
+        assert (proto1, value) == (proto2, value) == item
+        assert proto1 in ma
+        assert proto2 in ma.keys()
+        assert item in ma.items()
+        assert value in ma.values()
+        assert ma.keys()[idx] == ma.keys()[idx-len(ma)] == proto1 == proto2
+        assert ma.items()[idx] == ma.items()[idx-len(ma)] == item
+        assert ma.values()[idx] == ma.values()[idx-len(ma)] == ma[proto1] == value
+
+    assert len(ma.keys()) == len(ma.items()) == len(ma.values()) == len(ma)
+    assert len(list(ma.keys())) == len(ma.keys())
+    assert len(list(ma.items())) == len(ma.items())
+    assert len(list(ma.values())) == len(ma.values())
+    
+    with pytest.raises(IndexError):
+        ma.keys()[len(ma)]
+    with pytest.raises(IndexError):
+        ma.items()[len(ma)]
+    with pytest.raises(IndexError):
+        ma.values()[len(ma)]
+
+
 def test_bad_initialization_no_params():
     with pytest.raises(TypeError):
         Multiaddr()

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -190,17 +190,17 @@ def test_get_value():
         "p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
 
     assert_value_for_proto(ma, P_IP4, "127.0.0.1")
-    assert_value_for_proto(ma, P_UTP, "")
+    assert_value_for_proto(ma, P_UTP, None)
     assert_value_for_proto(ma, P_TCP, "5555")
     assert_value_for_proto(ma, P_UDP, "1234")
     assert_value_for_proto(
         ma, P_P2P, "QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
     assert_value_for_proto(ma, "ip4", "127.0.0.1")
-    assert_value_for_proto(ma, "utp", "")
+    assert_value_for_proto(ma, "utp", None)
     assert_value_for_proto(ma, "tcp", "5555")
     assert_value_for_proto(ma, "udp", "1234")
     assert_value_for_proto(ma, protocol_with_name("ip4"), "127.0.0.1")
-    assert_value_for_proto(ma, protocol_with_name("utp"), "")
+    assert_value_for_proto(ma, protocol_with_name("utp"), None)
     assert_value_for_proto(ma, protocol_with_name("tcp"), "5555")
     assert_value_for_proto(ma, protocol_with_name("udp"), "1234")
 
@@ -224,7 +224,7 @@ def test_get_value():
     a = Multiaddr("/ip4/0.0.0.0/udp/12345/utp")  # ending in a no-value one.
     assert_value_for_proto(a, P_IP4, "0.0.0.0")
     assert_value_for_proto(a, P_UDP, "12345")
-    assert_value_for_proto(a, P_UTP, "")
+    assert_value_for_proto(a, P_UTP, None)
 
     a = Multiaddr("/ip4/0.0.0.0/unix/a/b/c/d")  # ending in a path one.
     assert_value_for_proto(a, P_IP4, "0.0.0.0")

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -72,6 +72,7 @@ def test_protocol_with_name():
     assert proto.code == protocols.P_IP4
     assert proto.size == 32
     assert proto.vcode == varint.encode(protocols.P_IP4)
+    assert hash(proto) == protocols.P_IP4
 
     with pytest.raises(exceptions.ProtocolNotFoundError):
         proto = protocols.protocol_with_name('foo')
@@ -83,6 +84,7 @@ def test_protocol_with_code():
     assert proto.code == protocols.P_IP4
     assert proto.size == 32
     assert proto.vcode == varint.encode(protocols.P_IP4)
+    assert hash(proto) == protocols.P_IP4
 
     with pytest.raises(exceptions.ProtocolNotFoundError):
         proto = protocols.protocol_with_code(1234)
@@ -95,6 +97,8 @@ def test_protocol_equality():
 
     assert proto1 == proto2
     assert proto1 != proto3
+    assert proto1 != None
+    assert proto2 != str(proto2)
 
 
 @pytest.mark.parametrize("names", [['ip4'],


### PR DESCRIPTION
Changes (from commit messages):

  * Return `None` on `value_for_protocol` that does not have any value
  * Mark all segments of Python 2-only code as *pragma: no cover*
     - This way such code is not considered by the coverage analyser, causing testing failures for Python 2 to not look like they decrease coverage and giving the actually relevant coverage figure when running `tox -e py3` rather than marking the Python 2 lines as untested in this case.
  * Implement `collections.abc.Mapping` for `Multiaddr` to give it a dict-style feel
    - Nit: All operations on this “dictionary” (including __len__ and __getitem__) are O(n) over the number of
bytes/protocols of the MultiAddr, rather then using more optimized code that would require pre-parsing the binary MultiAddr. Considering that MultiAddr tend to be rather short this should hopefully not be an issue, but changing this would be possible in the future without changing any part of the interface.
  * Do not allow empty text MultiAddrs, they must now always start with a forward slash
  * Make `Multiaddr` a “copy-constructor” and use it where we except any MultiAddr to be more flexible about the types we may receive

This basically addresses all things were I thought “That is kinda inconvenient” or “This doesn't really make sense” during my previous iterations of improving this library.

After this I have no more pending patches and would appreciate a release. :slightly_smiling_face: 