### PR TITLE
Add `multiaddr.Multiaddr.split(self, maxsplit=-1)` and `multiaddr.Multiaddr.join(*addrs)`

### DIFF
--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import binascii
 import six
 import varint
 
@@ -116,31 +115,6 @@ class Protocol(object):
             name=self.name,
             codec=self.codec,
         )
-
-
-def _uvarint(buf):
-    """Reads a varint from a bytes buffer and returns the value and # bytes"""
-    x = 0
-    s = 0
-    for i, b_str in enumerate(buf):
-        if six.PY3:
-            b = b_str
-        else:  # pragma: no cover (PY2)
-            b = int(binascii.b2a_hex(b_str), 16)
-        if b < 0x80:
-            if i > 9 or (i == 9 and b > 1):
-                # Code 34 apparently means `OverflowError`
-                # (as opposed to other `ArithmeticError` types)
-                raise OverflowError(34, "UVarInt too large")
-            return (x | b << s, i + 1)
-        x |= (b & 0x7f) << s
-        s += 7
-    return 0, 0
-
-
-def read_varint_code(buf):
-    num, n = _uvarint(buf)
-    return int(num), n
 
 
 # Protocols is the list of multiaddr protocols supported by this module.

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -159,6 +159,33 @@ def test_invalid_protocols_with_string(proto_string):
         protocols_with_string(proto_string)
 
 
+@pytest.mark.parametrize(
+    'proto_string,maxsplit,expected',
+    [("/ip4/1.2.3.4", -1, ("/ip4/1.2.3.4",)),
+     ("/ip4/0.0.0.0", 0, ("/ip4/0.0.0.0",)),
+     ("/ip6/::1", 1, ("/ip6/::1",)),
+     ("/onion/timaq4ygg2iegci7:80/http", 0, ("/onion/timaq4ygg2iegci7:80/http",)),
+     ("/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234", 1,
+      ("/ip4/127.0.0.1", "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",)),
+     ("/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f", -1,
+      ("/ip4/1.2.3.4", "/tcp/80", "/unix/a/b/c/d/e/f"))])
+def test_split(proto_string, maxsplit, expected):
+    assert tuple(map(str, Multiaddr(proto_string).split(maxsplit))) == expected
+
+
+@pytest.mark.parametrize(
+    'proto_parts,expected',
+    [(("/ip4/1.2.3.4",), "/ip4/1.2.3.4"),
+     ((b"\x04\x00\x00\x00\x00",), "/ip4/0.0.0.0"),
+     (("/ip6/::1",), "/ip6/::1"),
+     (("/onion/timaq4ygg2iegci7:80/http",), "/onion/timaq4ygg2iegci7:80/http"),
+     ((b"\x04\x7F\x00\x00\x01", "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",),
+      "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234"),
+     (("/ip4/1.2.3.4", "/tcp/80", "/unix/a/b/c/d/e/f"), "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f")])
+def test_join(proto_parts, expected):
+    assert str(Multiaddr.join(*proto_parts)) == expected
+
+
 def test_encapsulate():
     m1 = Multiaddr("/ip4/127.0.0.1/udp/1234")
     m2 = Multiaddr("/udp/5678")

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -161,15 +161,3 @@ def test_add_protocol_twice(patch_protocols, valid_params):
 def test_protocol_repr():
     proto = protocols.protocol_with_name('ip4')
     assert "Protocol(code=4, name='ip4', codec='ip4')" == repr(proto)
-
-
-@pytest.mark.parametrize("buf", [
-    b'\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x01',
-    b'\x90\x91\x92\x93\x94\x95\x96\x97\x98\x02'])
-def test_overflowing_varint(buf):
-    with pytest.raises(OverflowError):
-        protocols.read_varint_code(buf)
-
-
-def test_nonterminated_varint():
-    assert protocols.read_varint_code(b'\x80\x80') == (0, 0)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+import io
+
 import pytest
 
 from multiaddr.codecs import codec_by_name
@@ -57,7 +59,8 @@ BYTES_MAP_STR_TEST_DATA = [
     ('p2p', b'\x40\x50\x60\x51', (64, 1)),
 ])
 def test_size_for_addr(codec_name, buf, expected):
-    assert size_for_addr(codec_by_name(codec_name), buf) == expected
+    buf_io = io.BytesIO(buf)
+    assert (size_for_addr(codec_by_name(codec_name), buf_io), buf_io.tell()) == expected
 
 
 @pytest.mark.parametrize("buf, expected", [
@@ -69,7 +72,7 @@ def test_size_for_addr(codec_name, buf, expected):
       (_names_to_protocols["tcp"], b'\x10\xe1')]),
 ])
 def test_bytes_iter(buf, expected):
-    assert list((proto, val) for proto, _, val in bytes_iter(buf)) == expected
+    assert list((proto, val) for _, proto, _, val in bytes_iter(buf)) == expected
 
 
 @pytest.mark.parametrize("proto, buf, expected", ADDR_BYTES_MAP_STR_TEST_DATA)


### PR DESCRIPTION
Re-adds the APIs gone missing mentioned in #47

Also replaces `multiaddr.protocols.read_varint_code` with `varint.decode_stream` because it was more convinient to use this standard API than the current homebrew code.