### PR TITLE
Fix broken reST and links

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,3 @@
-=======
 History
 =======
 
@@ -14,6 +13,9 @@ History
 * unhexilified bytes
 * new exceptions
 * miscellaneous improvements [via alexander255_ `#42`_]
+
+.. _alexander255: https://github.com/alexander255
+.. _`#42`: https://github.com/multiformats/py-multiaddr/pull/42
 
 0.0.2 (2016-5-4)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ py-multiaddr
 .. image:: https://img.shields.io/pypi/v/multiaddr.svg
         :target: https://pypi.python.org/pypi/multiaddr
 
-.. image:: https://travis-ci.org/multiformats/py-multiaddr.svg?branch=master
-        :target: https://travis-ci.org/multiformats/py-multiaddr
+.. image:: https://api.travis-ci.com/multiformats/py-multiaddr.svg?branch=master
+        :target: https://travis-ci.com/multiformats/py-multiaddr
 
 .. image:: https://codecov.io/github/multiformats/py-multiaddr/coverage.svg?branch=master
         :target: https://codecov.io/github/multiformats/py-multiaddr?branch=master
@@ -122,3 +122,4 @@ Dual-licensed:
 .. _standard-readme: https://github.com/RichardLitt/standard-readme
 .. _MIT: LICENSE-MIT
 .. _Apache 2: LICENSE-APACHE2
+.. _`@sbuss`: https://github.com/sbuss

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 bumpversion==0.5.3
-wheel==0.29.0
+wheel>=0.31.0
 watchdog==0.8.3
 tox==3.6.1
 coverage==4.5.2

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     version=version,
     description="Python implementation of jbenet's multiaddr",
     long_description=readme + '\n\n' + history,
+    long_description_content_type="text/x-rst",
     author="Steven Buss",
     author_email='steven.buss@gmail.com',
     url='https://github.com/multiformats/py-multiaddr',


### PR DESCRIPTION
### Done

- Invalid `long_description` is no longer accepted in PyPI, which makes us unable to upload the package without fixing the syntax errors in `HISTORY.rst` and `README.rst`. 
- Besides, fixes the failing image of travis-ci

Ref: https://github.com/pypa/warehouse/issues/5890#issuecomment-494868157