### PR TITLE
remove emoji from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ py-multiaddr
         :alt: Documentation Status
 ..
 
-    multiaddr_ implementation in Python 🐍
+    multiaddr_ implementation in Python
 
 .. _multiaddr: https://github.com/multiformats/multiaddr
 


### PR DESCRIPTION
Having an unicode emoji in the readme is creating encoding errors.
This is on windows python 3.7, one of the supported versions:
```
(venv) ...\py-multiaddr>pip install -e .
Obtaining file:///C:/Users/jonat/code/py-multiaddr
    ERROR: Command errored out with exit status 1:
     command: '..\py-multiaddr\venv\Scripts\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'..\\py-multiaddr\\setup.py'"'"'; __file__='"'"'..\\py-multiaddr\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.cl
ose();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: ...\py-multiaddr\
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "...\py-multiaddr\setup.py", line 12, in <module>
        readme = readme_file.read()
      File "<Python3.8>\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 722: character maps to <undefined>
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
This same error also pops up in `tox` when trying to initiate a test.