### PR TITLE
add __hash__ function to Multiaddr

### DIFF
--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -170,6 +170,9 @@ class Multiaddr(collections.abc.Mapping):
     def __repr__(self):
         return "<Multiaddr %s>" % str(self)
 
+    def __hash__(self):
+        return self._bytes.__hash__()
+
     def to_bytes(self):
         """Returns the byte array representation of this Multiaddr."""
         return self._bytes

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -355,3 +355,9 @@ def test_zone():
 
     maddr_from_bytes = Multiaddr(ip6_bytes)
     assert str(maddr_from_bytes) == ip6_string
+
+
+def test_hash():
+    addr_bytes = Multiaddr("/ip4/127.0.0.1/udp/1234").to_bytes()
+
+    assert hash(Multiaddr(addr_bytes)) == hash(addr_bytes)


### PR DESCRIPTION
`Multiaddr` is currently unhashable, that means that it cannot be used in sets, dicts (as keys), frozentuples, tuples, and with much more internal logic that all depend on `__hash__` functions.

Internally, `Multiaddr` uses a bytes variable for it's internal state, which can be hashed.

This PR adds a simple __hash__ function that uses the hash function of those bytes, effectively making `Multiaddr` hashable.

Example of where this would be useful:
```
(self.multiaddrs is of type set)
>       self.multiaddrs.update(_multiaddr_from_socket(sock) for sock in self.server.sockets)
E       TypeError: unhashable type: 'Multiaddr'
```