### PR TITLE
Fix missing multiaddr/codecs and multiaddr/resolvers subpackages in distribution

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
    contributing
    authors
    history
+   modules
 
 Indices and tables
 ==================
@@ -23,4 +24,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/multiaddr.rst
+++ b/docs/multiaddr.rst
@@ -45,6 +45,14 @@ multiaddr.transforms module
    :show-inheritance:
    :undoc-members:
 
+multiaddr.utils module
+----------------------
+
+.. automodule:: multiaddr.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/examples/thin_waist/README.md
+++ b/examples/thin_waist/README.md
@@ -1,0 +1,107 @@
+# Thin Waist Address Validation Examples
+
+This directory contains examples demonstrating how to use the thin waist address validation functionality in the Python multiaddr library.
+
+## What is Thin Waist Address Validation?
+
+Thin waist address validation is a technique used in libp2p to:
+- Process multiaddrs and extract thin waist addresses (IP + transport protocol)
+- Expand wildcard addresses (like `0.0.0.0` or `::`) to all available network interfaces
+- Override ports when needed
+- Filter out link-local addresses
+
+## Example File
+
+### `thin_waist_example.py`
+
+A comprehensive example that demonstrates all aspects of thin waist address validation.
+
+**Usage:**
+```bash
+# Basic examples only
+python examples/thin_waist/thin_waist_example.py
+
+# Detailed examples with edge cases and practical scenarios
+python examples/thin_waist/thin_waist_example.py --detailed
+```
+
+**What it demonstrates:**
+
+**Basic Examples:**
+1. Specific IP addresses (no expansion)
+2. IPv4 wildcard expansion (`0.0.0.0` → all IPv4 interfaces)
+3. IPv6 wildcard expansion (`::` → all IPv6 interfaces)
+4. Port override functionality
+5. Handling empty input
+
+**Detailed Examples (with `--detailed` flag):**
+6. UDP transport support
+7. Port override on specific addresses
+8. Error handling for invalid multiaddrs
+9. Server binding scenarios
+10. Dynamic port configuration
+
+## Key Functions
+
+### `get_thin_waist_addresses(ma=None, port=None)`
+
+The main function for thin waist address validation.
+
+**Parameters:**
+- `ma`: A Multiaddr object (optional)
+- `port`: Port number to override (optional)
+
+**Returns:**
+- List of Multiaddr objects representing thin waist addresses
+
+**Examples:**
+
+```python
+from multiaddr import Multiaddr
+from multiaddr.utils import get_thin_waist_addresses
+
+# Specific address (no expansion)
+addr = Multiaddr('/ip4/192.168.1.100/tcp/8080')
+result = get_thin_waist_addresses(addr)
+# Returns: [<Multiaddr /ip4/192.168.1.100/tcp/8080>]
+
+# Wildcard expansion
+addr = Multiaddr('/ip4/0.0.0.0/tcp/8080')
+result = get_thin_waist_addresses(addr)
+# Returns: [<Multiaddr /ip4/192.168.1.12/tcp/8080>, <Multiaddr /ip4/10.152.168.99/tcp/8080>]
+
+# Port override
+addr = Multiaddr('/ip4/0.0.0.0/tcp/8080')
+result = get_thin_waist_addresses(addr, port=9000)
+# Returns: [<Multiaddr /ip4/192.168.1.12/tcp/9000>, <Multiaddr /ip4/10.152.168.99/tcp/9000>]
+```
+
+## Use Cases
+
+1. **Server Configuration**: Expand wildcard addresses to bind to all interfaces
+2. **Network Discovery**: Find all available network interfaces
+3. **Port Management**: Override ports in multiaddrs
+4. **Address Validation**: Ensure multiaddrs represent valid thin waist addresses
+
+## Requirements
+
+- Python 3.9+
+- `multiaddr` library with `psutil` dependency
+- Network interfaces to demonstrate wildcard expansion
+
+## Running the Example
+
+Make sure you have the virtual environment activated and all dependencies installed:
+
+```bash
+# Activate virtual environment
+source venv/bin/activate
+
+# Run basic examples
+python examples/thin_waist/thin_waist_example.py
+
+# Run detailed examples
+python examples/thin_waist/thin_waist_example.py --detailed
+```
+
+The output will show your actual network interfaces and demonstrate how wildcard addresses are expanded to specific IP addresses on your system.

--- a/examples/thin_waist/thin_waist_example.py
+++ b/examples/thin_waist/thin_waist_example.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Thin Waist Address Validation Example
+
+This example demonstrates how to use the get_thin_waist_addresses function
+to process multiaddrs and expand wildcard addresses to all available interfaces.
+
+Usage:
+    python examples/thin_waist/thin_waist_example.py [--detailed]
+"""
+
+import sys
+
+from multiaddr import Multiaddr
+from multiaddr.utils import get_network_addrs, get_thin_waist_addresses
+
+
+def show_network_info():
+    """Display available network interfaces."""
+    print("=== Network Interface Information ===")
+
+    # Get all IPv4 addresses
+    ipv4_addrs = get_network_addrs(4)
+    print(f"Available IPv4 addresses: {ipv4_addrs}")
+
+    # Get all IPv6 addresses
+    ipv6_addrs = get_network_addrs(6)
+    print(f"Available IPv6 addresses: {ipv6_addrs}")
+    print()
+
+
+def basic_examples():
+    """Show basic thin waist address validation examples."""
+    print("=== Basic Examples ===")
+
+    # Example 1: Specific address (no expansion)
+    print("\n1. Specific IP address:")
+    addr = Multiaddr("/ip4/192.168.1.100/tcp/8080")
+    print(f"   Input:  {addr}")
+    result = get_thin_waist_addresses(addr)
+    print(f"   Output: {result}")
+
+    # Example 2: IPv4 wildcard expansion
+    print("\n2. IPv4 wildcard expansion:")
+    addr = Multiaddr("/ip4/0.0.0.0/tcp/8080")
+    print(f"   Input:  {addr}")
+    result = get_thin_waist_addresses(addr)
+    print("   Output:")
+    for i, expanded in enumerate(result, 1):
+        print(f"     {i}. {expanded}")
+
+    # Example 3: IPv6 wildcard expansion
+    print("\n3. IPv6 wildcard expansion:")
+    addr = Multiaddr("/ip6/::/tcp/8080")
+    print(f"   Input:  {addr}")
+    result = get_thin_waist_addresses(addr)
+    print("   Output:")
+    for i, expanded in enumerate(result, 1):
+        print(f"     {i}. {expanded}")
+
+    # Example 4: Port override
+    print("\n4. Port override:")
+    addr = Multiaddr("/ip4/0.0.0.0/tcp/8080")
+    print(f"   Input:  {addr} (override port to 9000)")
+    result = get_thin_waist_addresses(addr, port=9000)
+    print("   Output:")
+    for i, expanded in enumerate(result, 1):
+        print(f"     {i}. {expanded}")
+
+    # Example 5: No input
+    print("\n5. No input:")
+    result = get_thin_waist_addresses()
+    print(f"   Output: {result}")
+
+
+def detailed_examples():
+    """Show detailed examples with more edge cases and explanations."""
+    print("\n=== Detailed Examples ===")
+
+    # Example: UDP transport
+    print("\n6. UDP transport:")
+    addr = Multiaddr("/ip4/0.0.0.0/udp/1234")
+    print(f"   Input:  {addr}")
+    result = get_thin_waist_addresses(addr)
+    print("   Output:")
+    for i, expanded in enumerate(result, 1):
+        print(f"     {i}. {expanded}")
+
+    # Example: Port override on specific address
+    print("\n7. Port override on specific address:")
+    addr = Multiaddr("/ip4/192.168.1.100/tcp/8080")
+    print(f"   Input:  {addr}")
+    result = get_thin_waist_addresses(addr, port=9000)
+    print(f"   Output: {result}")
+
+    # Example: Error handling
+    print("\n8. Error handling:")
+    try:
+        # Try to create an invalid multiaddr
+        addr = Multiaddr("/ip4/192.168.1.100/udp/1234/webrtc")
+        print(f"   Created address: {addr}")
+
+        # This should return empty list for non-thin-waist addresses
+        addrs = get_thin_waist_addresses(addr)
+        print(f"   Thin waist addresses: {addrs}")
+
+    except Exception as e:
+        print(f"   Error creating invalid address: {e}")
+
+
+def usage_examples():
+    """Show practical usage examples."""
+    print("\n=== Practical Usage Examples ===")
+
+    print("\n9. Server binding scenario:")
+    print("   When you want to bind a server to all interfaces:")
+    wildcard = Multiaddr("/ip4/0.0.0.0/tcp/8080")
+    interfaces = get_thin_waist_addresses(wildcard)
+    print(f"   Wildcard: {wildcard}")
+    print("   Available interfaces:")
+    for i, interface in enumerate(interfaces, 1):
+        print(f"     {i}. {interface}")
+
+    print("\n10. Port configuration scenario:")
+    print("    When you need to change the port dynamically:")
+    original = Multiaddr("/ip4/0.0.0.0/tcp/8080")
+    new_port = 9000
+    updated = get_thin_waist_addresses(original, port=new_port)
+    print(f"    Original: {original}")
+    print(f"    New port: {new_port}")
+    print("    Updated interfaces:")
+    for i, interface in enumerate(updated, 1):
+        print(f"      {i}. {interface}")
+
+
+def main():
+    """Run the thin waist address validation examples."""
+    print("Thin Waist Address Validation Example")
+    print("=" * 50)
+
+    # Check for detailed mode
+    detailed = "--detailed" in sys.argv
+
+    # Show network information
+    show_network_info()
+
+    # Show basic examples
+    basic_examples()
+
+    # Show detailed examples if requested
+    if detailed:
+        detailed_examples()
+        usage_examples()
+
+    print("\n" + "=" * 50)
+    print("Example completed!")
+    if not detailed:
+        print("Run with --detailed flag for more examples and edge cases.")
+
+
+if __name__ == "__main__":
+    main()

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -299,6 +299,7 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
 
     async def resolve(self) -> list["Multiaddr"]:
         """Resolve this multiaddr if it contains a resolvable protocol.
+
         Returns:
             A list of resolved multiaddrs
         """

--- a/multiaddr/utils.py
+++ b/multiaddr/utils.py
@@ -1,0 +1,119 @@
+import socket
+from typing import Any, Optional
+
+import psutil
+
+from .multiaddr import Multiaddr
+
+
+def is_wildcard(ip: str) -> bool:
+    """Check if an IP address is a wildcard address."""
+    return ip in ["0.0.0.0", "::"]
+
+
+def get_network_addrs(family: int) -> list[str]:
+    """Get all network addresses for a given IP family (4 for IPv4, 6 for IPv6)."""
+    addresses = []
+    for iface, addrs in psutil.net_if_addrs().items():
+        for addr in addrs:
+            if family == 4 and addr.family == socket.AF_INET:
+                if addr.address != "127.0.0.1" and not is_link_local_ip(addr.address):
+                    addresses.append(addr.address)
+            elif family == 6 and addr.family == socket.AF_INET6:
+                if not addr.address.startswith("::1") and not is_link_local_ip(addr.address):
+                    # Remove the %scope_id if present
+                    addresses.append(addr.address.split("%")[0])
+    return addresses
+
+
+def is_link_local_ip(ip: str) -> bool:
+    """Check if an IP address is link-local."""
+    if ":" in ip:  # IPv6
+        return ip.startswith("fe80:")
+    else:  # IPv4
+        parts = ip.split(".")
+        return len(parts) == 4 and parts[0] == "169" and parts[1] == "254"
+
+
+def get_multiaddr_options(ma: Multiaddr) -> Optional[dict[str, Any]]:
+    """Extract options from a multiaddr (similar to toOptions() in JS).
+
+    Returns a dictionary with 'family', 'host', 'transport', and 'port' keys,
+    or None if the multiaddr doesn't represent a thin waist address.
+    """
+    if ma is None:
+        return None
+
+    # Parse the multiaddr to extract IP and transport information
+    parts = str(ma).strip("/").split("/")
+
+    if len(parts) < 4:
+        return None
+
+    # Look for IP protocol (ip4 or ip6)
+    ip_proto = None
+    ip_addr = None
+    transport_proto = None
+    port = None
+
+    for i, part in enumerate(parts):
+        if part in ["ip4", "ip6"]:
+            if i + 1 < len(parts):
+                ip_proto = part
+                ip_addr = parts[i + 1]
+        elif part in ["tcp", "udp"]:
+            if i + 1 < len(parts):
+                transport_proto = part
+                try:
+                    port = int(parts[i + 1])
+                except (ValueError, IndexError):
+                    return None
+
+    if not all([ip_proto, ip_addr, transport_proto, port]):
+        return None
+
+    family = 4 if ip_proto == "ip4" else 6
+
+    return {"family": family, "host": ip_addr, "transport": transport_proto, "port": port}
+
+
+def get_thin_waist_addresses(
+    ma: Optional[Multiaddr] = None, port: Optional[int] = None
+) -> list[Multiaddr]:
+    """Get all thin waist addresses on the current host that match the family of the
+    passed multiaddr and optionally override the port.
+
+    Wildcard IP4/6 addresses will be expanded into all available interfaces.
+
+    Args:
+        ma: The multiaddr to process. If None, returns empty list.
+        port: Optional port to override the port in the multiaddr.
+
+    Returns:
+        List of Multiaddr objects representing thin waist addresses.
+    """
+    if ma is None:
+        return []
+
+    options = get_multiaddr_options(ma)
+    if options is None:
+        return []
+
+    # Use provided port or fall back to the one in the multiaddr
+    target_port = port if port is not None else options["port"]
+
+    ip_proto = "ip4" if options["family"] == 4 else "ip6"
+
+    if is_wildcard(options["host"]):
+        # Expand wildcard addresses to all available interfaces
+        addrs = []
+        for host in get_network_addrs(options["family"]):
+            if not is_link_local_ip(host):
+                # Correct multiaddr format: /ip4/host/tcp/port or /ip6/host/tcp/port
+                addr_str = f"/{ip_proto}/{host}/{options['transport']}/{target_port}"
+                addrs.append(Multiaddr(addr_str))
+        return addrs
+    else:
+        # Return the specific address
+        addr_str = f"/{ip_proto}/{options['host']}/{options['transport']}/{target_port}"
+        return [Multiaddr(addr_str)]

--- a/newsfragments/72.feature.rst
+++ b/newsfragments/72.feature.rst
@@ -1,0 +1,1 @@
+Add thin waist address validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "dnspython>=2.7.0",
     "idna",
     "netaddr",
+    "psutil",
     "py-cid",
     "py-multicodec >= 0.2.0",
     "trio-typing>=0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,13 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["multiaddr"]
+# packages = ["multiaddr"]
 include-package-data = true
 zip-safe = false
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["multiaddr*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -122,7 +126,7 @@ name = "Removals"
 showcontent = true
 
 [tool.bumpversion]
-current_version = "0.0.9"
+current_version = "0.0.10"
 parse = """
     (?P<major>\\d+)
     \\.(?P<minor>\\d+)

--- a/tests/test_thin_waist_addresses.py
+++ b/tests/test_thin_waist_addresses.py
@@ -1,0 +1,72 @@
+import pytest
+
+from multiaddr import Multiaddr
+from multiaddr.exceptions import StringParseError
+from multiaddr.utils import get_thin_waist_addresses
+
+
+def test_no_address():
+    assert get_thin_waist_addresses() == []
+    assert get_thin_waist_addresses(None) == []
+
+
+def test_specific_address():
+    input_addr = Multiaddr("/ip4/123.123.123.123/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr)
+    assert addrs == [input_addr]
+
+
+def test_specific_address_override_port():
+    input_addr = Multiaddr("/ip4/123.123.123.123/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr, 100)
+    assert addrs == [Multiaddr("/ip4/123.123.123.123/tcp/100")]
+
+
+def test_ignore_non_thin_waist():
+    # Should raise StringParseError for unknown protocol (e.g. /webrtc)
+    with pytest.raises(StringParseError):
+        Multiaddr("/ip4/123.123.123.123/udp/1234/webrtc")
+
+
+def test_ipv4_wildcard():
+    input_addr = Multiaddr("/ip4/0.0.0.0/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr)
+    assert len(addrs) > 0
+    for addr in addrs:
+        s = str(addr)
+        assert s.startswith("/ip4/")
+        assert "/tcp/1234" in s
+        assert not s.startswith("/ip4/0.0.0.0")
+
+
+def test_ipv4_wildcard_override_port():
+    input_addr = Multiaddr("/ip4/0.0.0.0/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr, 100)
+    assert len(addrs) > 0
+    for addr in addrs:
+        s = str(addr)
+        assert s.startswith("/ip4/")
+        assert "/tcp/100" in s
+        assert not s.startswith("/ip4/0.0.0.0")
+
+
+def test_ipv6_wildcard():
+    input_addr = Multiaddr("/ip6/::/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr)
+    assert len(addrs) >= 0  # May be 0 if no IPv6 interfaces
+    for addr in addrs:
+        s = str(addr)
+        assert s.startswith("/ip6/")
+        assert "/tcp/1234" in s
+        assert not s.startswith("/ip6/::")
+
+
+def test_ipv6_wildcard_override_port():
+    input_addr = Multiaddr("/ip6/::/tcp/1234")
+    addrs = get_thin_waist_addresses(input_addr, 100)
+    assert len(addrs) >= 0  # May be 0 if no IPv6 interfaces
+    for addr in addrs:
+        s = str(addr)
+        assert s.startswith("/ip6/")
+        assert "/tcp/100" in s
+        assert not s.startswith("/ip6/::")


### PR DESCRIPTION
Fix issue:
https://github.com/multiformats/py-multiaddr/issues/78

## Problem

The `multiaddr/codecs` and `multiaddr/resolvers` subpackages were not being included in the distribution package, causing installation failures when users tried to install the package from the built distribution.

## Root Cause

The `pyproject.toml` configuration was using:
```toml
[tool.setuptools]
# packages = ["multiaddr"]
include-package-data = true
zip-safe = false
```

The commented out `packages = ["multiaddr"]` line and lack of proper package discovery configuration meant that setuptools wasn't finding the subpackages.

## Solution

Updated the setuptools configuration to use the `find` packages feature:

```toml
[tool.setuptools.packages.find]
where = ["."]
include = ["multiaddr*"]
```

This ensures that setuptools will automatically discover and include all subpackages that match the `multiaddr*` pattern.

## Changes

- **pyproject.toml**: Added proper package discovery configuration to include all multiaddr subpackages

## Testing

After this fix:
- `make dist` includes all subpackages in the distribution
- `pip install dist/multiaddr-*.tar.gz` installs the complete package
- All imports work: `from multiaddr.codecs import ...` and `from multiaddr.resolvers import ...`

## Impact

This ensures that the distribution package is complete and functional for end users, including all codecs and resolvers functionality.