### PR TITLE
feat: add full dnsaddr, dns4, dns6 protocols and examples and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,16 @@ En/decapsulate
     m1.decapsulate(Multiaddr("/udp"))
     # <Multiaddr /ip4/127.0.0.1>
 
+    # Decapsulate by protocol code
+    m2 = Multiaddr("/ip4/192.168.1.1/tcp/8080/udp/1234")
+    m2.decapsulate_code(6)  # TCP protocol code
+    # <Multiaddr /ip4/192.168.1.1>
+
+    # Decapsulate multiple layers
+    m3 = Multiaddr("/ip4/10.0.0.1/tcp/443/tls/p2p/QmPeer")
+    m3.decapsulate_code(6)  # Remove TCP and everything after
+    # <Multiaddr /ip4/10.0.0.1>
+
 
 Tunneling
 ---------
@@ -114,10 +124,21 @@ Multiaddr supports DNS-based address resolution using the DNSADDR protocol. This
     # [Multiaddr("/ip4/93.184.216.34"), Multiaddr("/ip6/2606:2800:220:1:248:1893:25c8:1946")]
 
     # DNSADDR with peer ID (bootstrap node style)
-    ma_with_peer = Multiaddr("/dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
+    ma_with_peer = Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
     resolved_with_peer = await ma_with_peer.resolve()
     print(resolved_with_peer)
-    # [Multiaddr("/ip4/140.82.121.4/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")]
+    # [Multiaddr("/ip4/147.75.83.83/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")]
+
+    # DNS4 and DNS6 resolution (IPv4/IPv6 specific)
+    ma_dns4 = Multiaddr("/dns4/example.com/tcp/443")
+    resolved_dns4 = await ma_dns4.resolve()
+    print(resolved_dns4)
+    # [Multiaddr("/ip4/93.184.216.34/tcp/443")]
+
+    ma_dns6 = Multiaddr("/dns6/example.com/tcp/443")
+    resolved_dns6 = await ma_dns6.resolve()
+    print(resolved_dns6)
+    # [Multiaddr("/ip6/2606:2800:220:1:248:1893:25c8:1946/tcp/443")]
 
     # Using the DNS resolver directly
     from multiaddr.resolvers import DNSResolver
@@ -170,7 +191,7 @@ Multiaddr provides thin waist address validation functionality to process multia
     addr = Multiaddr("/ip6/::/tcp/8080")
     result = get_thin_waist_addresses(addr)
     print(result)
-    # [<Multiaddr /ip6/fd9b:9eba:8224:1:41a1:8939:231a:b414/tcp/8080>]
+    # [<Multiaddr /ip6/::1/tcp/8080>, <Multiaddr /ip6/fd9b:9eba:8224:1:41a1:8939:231a:b414/tcp/8080>]
 
     # Port override
     addr = Multiaddr("/ip4/0.0.0.0/tcp/8080")

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,159 @@
+Examples
+========
+
+This section provides practical examples of how to use the multiaddr library for various use cases.
+
+DNS Resolution Examples
+-----------------------
+
+The `examples/dns/` directory contains comprehensive examples demonstrating DNS-based address resolution.
+
+.. code-block:: python
+
+    # Basic DNS resolution with multiple protocols
+    from multiaddr import Multiaddr
+    import trio
+
+    async def main():
+        # Standard DNS resolution
+        ma = Multiaddr("/dns/example.com")
+        resolved = await ma.resolve()
+        print(f"Resolved: {resolved}")
+
+        # DNS4 (IPv4-specific) resolution
+        ma_dns4 = Multiaddr("/dns4/example.com/tcp/443")
+        resolved_dns4 = await ma_dns4.resolve()
+        print(f"DNS4 resolved: {resolved_dns4}")
+
+        # DNS6 (IPv6-specific) resolution
+        ma_dns6 = Multiaddr("/dns6/example.com/tcp/443")
+        resolved_dns6 = await ma_dns6.resolve()
+        print(f"DNS6 resolved: {resolved_dns6}")
+
+    trio.run(main)
+
+Key features demonstrated:
+- Standard DNS resolution for both IPv4 and IPv6
+- Protocol-specific DNS resolution (dns4/dns6)
+- Peer ID preservation during resolution
+- Bootstrap node resolution using real libp2p nodes
+- Error handling and timeout management
+
+See `examples/dns/dns_examples.py` for the complete implementation.
+
+DNSADDR Examples
+----------------
+
+The `examples/dnsaddr/` directory shows how to work with DNSADDR records for libp2p bootstrap nodes.
+
+.. code-block:: python
+
+    from multiaddr import Multiaddr
+    import trio
+
+    async def main():
+        # DNSADDR resolution with peer ID
+        ma = Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
+        resolved = await ma.resolve()
+
+        for addr in resolved:
+            print(f"Bootstrap node: {addr}")
+            peer_id = addr.get_peer_id()
+            print(f"  Peer ID: {peer_id}")
+
+    trio.run(main)
+
+This example demonstrates:
+- DNSADDR record parsing and resolution
+- Peer ID extraction and preservation
+- Bootstrap node discovery
+- TXT record processing
+
+See `examples/dnsaddr/dnsaddr.py` for the complete implementation.
+
+Thin Waist Address Examples
+---------------------------
+
+The `examples/thin_waist/` directory demonstrates thin waist address validation and network interface discovery.
+
+.. code-block:: python
+
+    from multiaddr import Multiaddr
+    from multiaddr.utils import get_thin_waist_addresses
+
+    # Network interface discovery
+    addr = Multiaddr("/ip4/0.0.0.0/tcp/8080")
+    interfaces = get_thin_waist_addresses(addr)
+
+    print("Available interfaces:")
+    for i, interface in enumerate(interfaces, 1):
+        print(f"  {i}. {interface}")
+
+    # IPv6 wildcard expansion
+    addr_ipv6 = Multiaddr("/ip6/::/tcp/8080")
+    interfaces_ipv6 = get_thin_waist_addresses(addr_ipv6)
+
+    print("IPv6 interfaces:")
+    for interface in interfaces_ipv6:
+        print(f"  {interface}")
+
+This example shows:
+- Network interface discovery
+- Wildcard address expansion
+- IPv4 and IPv6 support
+- Port management
+- Server binding scenarios
+
+See `examples/thin_waist/thin_waist_example.py` for the complete implementation.
+
+Decapsulate Code Examples
+-------------------------
+
+The `examples/decapsulate/` directory demonstrates how to use the `decapsulate_code` method for protocol layer manipulation.
+
+.. code-block:: python
+
+    from multiaddr import Multiaddr
+    from multiaddr.protocols import P_TCP, P_TLS
+
+    # Remove specific protocol layers by code
+    ma = Multiaddr("/ip4/192.168.1.1/tcp/8080/tls/p2p/QmPeer")
+    print(f"Original: {ma}")
+
+    # Remove TLS layer
+    without_tls = ma.decapsulate_code(P_TLS)
+    print(f"Without TLS: {without_tls}")
+
+    # Remove TCP and everything after
+    base_addr = ma.decapsulate_code(P_TCP)
+    print(f"Base address: {base_addr}")
+
+This example demonstrates:
+- Protocol code-based layer removal
+- Protocol stack analysis
+- Address transformation
+- Error handling for edge cases
+- Practical network configuration scenarios
+
+See `examples/decapsulate/decapsulate_example.py` for the complete implementation.
+
+Running the Examples
+--------------------
+
+All examples can be run directly with Python:
+
+.. code-block:: bash
+
+    # DNS examples
+    python examples/dns/dns_examples.py
+
+    # DNSADDR examples
+    python examples/dnsaddr/dnsaddr.py
+
+    # Thin waist examples
+    python examples/thin_waist/thin_waist_example.py
+
+    # Decapsulate examples
+    python examples/decapsulate/decapsulate_example.py
+
+Note: Some examples require network connectivity and may take a few seconds to complete due to DNS resolution.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,16 +3,68 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Multiaddr's documentation!
-======================================
+Welcome to py-multiaddr's documentation!
+========================================
 
-Contents:
+What is Multiaddr?
+------------------
+
+Multiaddr is a format for encoding addresses from various well-established network protocols.
+It is useful for writing applications that future-proof their use of addresses and allow
+multiple transport protocols and addresses to coexist.
+
+A multiaddr emphasizes explicitness and self-description through the use of typed components.
+This makes it easier to write code that correctly handles addresses from different protocols,
+eliminating the need for address family detection and reducing the likelihood of bugs.
+
+Key Features
+------------
+
+* **Protocol Agnostic**: Support for IPv4, IPv6, TCP, UDP, DNS, HTTP, HTTPS, and many more protocols
+* **Self-Describing**: Each address component includes its protocol type, making addresses explicit and unambiguous
+* **Composable**: Addresses can be combined to represent complex network topologies and tunnels
+* **Future-Proof**: Easy to add new protocols without breaking existing code
+* **DNS Resolution**: Built-in support for DNS, DNS4, DNS6, and DNSADDR resolution
+* **Async Support**: Full async/await support with Trio for non-blocking operations
+* **Thin Waist Validation**: Network interface discovery and wildcard address expansion
+
+Supported Protocols
+-------------------
+
+The library supports a wide range of network protocols:
+
+* **Network Layer**: IPv4, IPv6, DNS, DNS4, DNS6, DNSADDR
+* **Transport Layer**: TCP, UDP, SCTP, DCCP, UDT, UTP
+* **Application Layer**: HTTP, HTTPS, WebSocket, WebSocket Secure
+* **Security**: TLS, Noise
+* **P2P**: libp2p peer IDs, circuit addresses
+* **Special**: Unix domain sockets, onion addresses
+
+Use Cases
+---------
+
+* **Distributed Systems**: Node discovery and addressing in peer-to-peer networks
+* **Microservices**: Service addressing and load balancing
+* **Network Programming**: Protocol-agnostic network applications
+* **DevOps**: Multi-protocol service configuration
+* **Research**: Network protocol experimentation and analysis
+
+Getting Started
+---------------
+
+* :doc:`readme` - Comprehensive usage guide with code examples
+* :doc:`installation` - Installation instructions and requirements
+* :doc:`examples` - Detailed examples for specific use cases
+
+Documentation Contents
+======================
 
 .. toctree::
    :maxdepth: 2
 
    readme
    installation
+   examples
    contributing
    authors
    history

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,6 +4,9 @@
 Installation
 ============
 
-Just install from pypi
+Requirements:
+- Python 3.9 or newer
+
+Install from PyPI:
 
     $ pip install multiaddr

--- a/examples/decapsulate/README.md
+++ b/examples/decapsulate/README.md
@@ -1,0 +1,80 @@
+# Decapsulate Code Examples
+
+This directory contains examples demonstrating the `decapsulate_code` functionality of the multiaddr library.
+
+## Overview
+
+The `decapsulate_code` method allows you to remove specific protocol layers from multiaddrs by their protocol codes. This is different from the standard `decapsulate` method which removes by multiaddr string.
+
+## Key Features
+
+- **Protocol Code Removal**: Remove layers by protocol code (e.g., TCP=6, UDP=17)
+- **Stack Analysis**: Analyze protocol stacks layer by layer
+- **Address Transformation**: Convert between different address formats
+- **Error Handling**: Proper handling of edge cases and errors
+
+## Examples Included
+
+### 1. Basic Decapsulate Examples
+Demonstrates fundamental usage of `decapsulate_code`:
+- Removing TCP layers
+- Removing UDP layers
+- Removing IP layers
+
+### 2. Protocol Stack Analysis
+Shows how to analyze complex multiaddr structures:
+- Layer-by-layer breakdown
+- Protocol identification
+- Stack visualization
+
+### 3. Address Transformation
+Practical scenarios for address manipulation:
+- Secure to insecure conversion
+- Transport layer extraction
+- IP version conversion simulation
+
+### 4. Error Handling
+Demonstrates proper error handling:
+- Non-existent protocol removal
+- Empty multiaddr handling
+- Edge case management
+
+### 5. Practical Use Cases
+Real-world applications:
+- Network configuration analysis
+- Protocol compatibility checking
+- Server/client address classification
+
+## Running the Examples
+
+```bash
+python examples/decapsulate/decapsulate_example.py
+```
+
+## Expected Output
+
+The examples will show:
+- Original multiaddr structures
+- Protocol information (names and codes)
+- Results after decapsulation
+- Error handling demonstrations
+- Practical use case analysis
+
+## Protocol Codes Reference
+
+Common protocol codes used in examples:
+- `P_IP4` (4): IPv4 addresses
+- `P_IP6` (41): IPv6 addresses
+- `P_TCP` (6): TCP transport
+- `P_UDP` (17): UDP transport
+- `P_TLS` (448): TLS security layer
+- `P_P2P` (421): P2P peer ID
+
+## Use Cases
+
+The `decapsulate_code` method is particularly useful for:
+- Network protocol analysis and debugging
+- Address format conversion
+- Protocol stack manipulation
+- Network configuration management
+- Compatibility checking between different protocols

--- a/examples/decapsulate/decapsulate_example.py
+++ b/examples/decapsulate/decapsulate_example.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Decapsulate Code Examples
+
+This example demonstrates how to use the decapsulate_code method to remove
+specific protocol layers from multiaddrs by their protocol codes.
+
+The decapsulate_code method is useful for:
+- Network protocol analysis
+- Protocol stack manipulation
+- Address transformation
+- Debugging multiaddr structures
+"""
+
+import sys
+
+from multiaddr import Multiaddr
+from multiaddr.protocols import P_IP4, P_IP6, P_TCP, P_TLS, P_UDP
+
+
+def print_separator(title):
+    """Print a formatted separator with title."""
+    print(f"\n{'=' * 60}")
+    print(f" {title}")
+    print(f"{'=' * 60}")
+
+
+def print_multiaddr_info(ma, description=""):
+    """Print multiaddr information in a formatted way."""
+    if description:
+        print(f"\n{description}:")
+    print(f"  String: {ma}")
+    print(f"  Protocols: {[p.name for p in ma.protocols()]}")
+    print(f"  Protocol codes: {[p.code for p in ma.protocols()]}")
+
+
+def basic_decapsulate_examples():
+    """Demonstrate basic decapsulate_code usage."""
+    print_separator("Basic Decapsulate Code Examples")
+
+    # Example 1: Remove TCP layer
+    ma1 = Multiaddr("/ip4/192.168.1.1/tcp/8080/udp/1234")
+    print_multiaddr_info(ma1, "Original multiaddr")
+
+    # Remove TCP (protocol code 6) and everything after it
+    result1 = ma1.decapsulate_code(P_TCP)
+    print_multiaddr_info(result1, "After decapsulating TCP (code 6)")
+
+    # Example 2: Remove UDP layer
+    ma2 = Multiaddr("/ip4/10.0.0.1/udp/1234/tcp/8080")
+    print_multiaddr_info(ma2, "Original multiaddr")
+
+    result2 = ma2.decapsulate_code(P_UDP)
+    print_multiaddr_info(result2, "After decapsulating UDP (code 17)")
+
+    # Example 3: Remove IP layer
+    ma3 = Multiaddr(
+        "/ip4/172.16.0.1/tcp/443/tls/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+    )
+    print_multiaddr_info(ma3, "Original multiaddr")
+
+    result3 = ma3.decapsulate_code(P_IP4)
+    print_multiaddr_info(result3, "After decapsulating IP4 (code 4)")
+
+
+def protocol_stack_analysis():
+    """Demonstrate protocol stack analysis using decapsulate_code."""
+    print_separator("Protocol Stack Analysis")
+
+    # Complex multiaddr with multiple layers
+    ma = Multiaddr(
+        "/ip4/192.168.1.100/tcp/8080/tls/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+    )
+    print_multiaddr_info(ma, "Complex multiaddr")
+
+    print("\nProtocol stack analysis:")
+    current = ma
+    layer = 1
+
+    while str(current) != "/":
+        print(f"  Layer {layer}: {current}")
+        protocols = list(current.protocols())
+        if protocols:
+            # Remove the last protocol layer
+            last_protocol = protocols[-1]
+            current = current.decapsulate_code(last_protocol.code)
+            layer += 1
+        else:
+            break
+
+
+def address_transformation():
+    """Demonstrate address transformation scenarios."""
+    print_separator("Address Transformation Examples")
+
+    # Example 1: Convert secure to insecure
+    secure_addr = Multiaddr(
+        "/ip4/10.0.0.1/tcp/443/tls/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+    )
+    print_multiaddr_info(secure_addr, "Secure address")
+
+    # Remove TLS layer to get insecure version
+    insecure_addr = secure_addr.decapsulate_code(P_TLS)
+    print_multiaddr_info(insecure_addr, "Insecure version (TLS removed)")
+
+    # Example 2: Extract base network address
+    full_addr = Multiaddr("/ip6/2001:db8::1/tcp/8080/udp/1234/sctp/5678")
+    print_multiaddr_info(full_addr, "Full address")
+
+    # Remove all transport layers to get just the IP address
+    base_addr = full_addr.decapsulate_code(P_TCP)
+    print_multiaddr_info(base_addr, "Base network address (transport removed)")
+
+    # Example 3: IPv4 to IPv6 conversion simulation
+    ipv4_addr = Multiaddr("/ip4/192.168.1.1/tcp/8080")
+    print_multiaddr_info(ipv4_addr, "IPv4 address")
+
+    # Simulate removing IPv4 to prepare for IPv6 replacement
+    transport_only = ipv4_addr.decapsulate_code(P_IP4)
+    print_multiaddr_info(transport_only, "Transport layer only (IP removed)")
+
+
+def error_handling_examples():
+    """Demonstrate error handling with decapsulate_code."""
+    print_separator("Error Handling Examples")
+
+    # Example 1: Protocol not found
+    ma = Multiaddr("/ip4/192.168.1.1/tcp/8080")
+    print_multiaddr_info(ma, "Original address")
+
+    try:
+        # Try to remove a protocol that doesn't exist
+        result = ma.decapsulate_code(P_UDP)  # UDP not in this address
+        print_multiaddr_info(result, "After removing non-existent UDP")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+    # Example 2: Empty multiaddr
+    empty_ma = Multiaddr("/")
+    print_multiaddr_info(empty_ma, "Empty multiaddr")
+
+    try:
+        result = empty_ma.decapsulate_code(P_TCP)
+        print_multiaddr_info(result, "After decapsulating from empty")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+
+def practical_use_cases():
+    """Demonstrate practical use cases for decapsulate_code."""
+    print_separator("Practical Use Cases")
+
+    # Use case 1: Network configuration analysis
+    print("Use Case 1: Network Configuration Analysis")
+    configs = [
+        "/ip4/0.0.0.0/tcp/8080",
+        "/ip4/0.0.0.0/tcp/8080/tls",
+        "/ip6/::/tcp/8080/tls/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        "/ip4/192.168.1.1/udp/1234",
+    ]
+
+    for config in configs:
+        ma = Multiaddr(config)
+        print(f"\n  Config: {ma}")
+
+        # Check if it's a server config (has wildcard IP)
+        if "0.0.0.0" in str(ma) or "::" in str(ma):
+            print("    Type: Server binding address")
+            # Extract transport info
+            transport = ma.decapsulate_code(
+                P_IP4 if P_IP4 in [p.code for p in ma.protocols()] else P_IP6
+            )
+            print(f"    Transport: {transport}")
+        else:
+            print("    Type: Client address")
+
+    # Use case 2: Protocol compatibility checking
+    print("\nUse Case 2: Protocol Compatibility Checking")
+    addresses = [
+        "/ip4/192.168.1.1/tcp/8080",
+        "/ip4/192.168.1.1/tcp/8080/tls",
+        "/ip6/2001:db8::1/udp/1234",
+    ]
+
+    for addr_str in addresses:
+        ma = Multiaddr(addr_str)
+        print(f"\n  Address: {ma}")
+
+        # Check if supports TLS
+        if P_TLS in [p.code for p in ma.protocols()]:
+            print("    TLS: Supported")
+            insecure = ma.decapsulate_code(P_TLS)
+            print(f"    Insecure version: {insecure}")
+        else:
+            print("    TLS: Not supported")
+
+        # Check transport protocol
+        if P_TCP in [p.code for p in ma.protocols()]:
+            print("    Transport: TCP")
+        elif P_UDP in [p.code for p in ma.protocols()]:
+            print("    Transport: UDP")
+
+
+def main():
+    """Run all decapsulate_code examples."""
+    print("Decapsulate Code Examples")
+    print("Demonstrating multiaddr protocol layer manipulation")
+
+    try:
+        basic_decapsulate_examples()
+        protocol_stack_analysis()
+        address_transformation()
+        error_handling_examples()
+        practical_use_cases()
+
+        print_separator("Summary")
+        print("The decapsulate_code method provides fine-grained control")
+        print("over multiaddr protocol layers, enabling:")
+        print("- Protocol stack analysis")
+        print("- Address transformation")
+        print("- Network configuration management")
+        print("- Protocol compatibility checking")
+
+    except KeyboardInterrupt:
+        print("\n\nExamples interrupted by user.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n\nError running examples: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dns/dns_examples.py
+++ b/examples/dns/dns_examples.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Trio-based DNS resolution examples for py-multiaddr.
+DNS resolution examples for py-multiaddr.
 
-This script demonstrates how to use DNS resolution functionality in py-multiaddr
-with trio, showing how to resolve bootstrap node addresses like those used in js-libp2p.
+This script demonstrates how to use DNS resolution functionality in py-multiaddr,
+showing how to resolve bootstrap node addresses like those used in js-libp2p.
 
 ## Overview
 
-This script shows various examples of DNS resolution using py-multiaddr with trio:
+This script shows various examples of DNS resolution using py-multiaddr:
 
 1. **Basic DNS Resolution**: Simple resolution of DNS addresses to IP addresses
 2. **Bootstrap Node Resolution**: Resolving real bootstrap node addresses with peer IDs
@@ -21,9 +21,9 @@ This script shows various examples of DNS resolution using py-multiaddr with tri
 When you run this script, you should see output similar to:
 
 ```
-DNS Resolution Examples with Trio
+DNS Resolution Examples
 ==================================================
-=== Basic DNS Resolution with Trio ===
+=== Basic DNS Resolution ===
 Original address: /dns/example.com
 Protocols: ['dns']
 Resolved to 12 addresses:
@@ -31,28 +31,33 @@ Resolved to 12 addresses:
   2. /ip4/23.215.0.136
   ... (more IPv4 and IPv6 addresses)
 
-=== Bootstrap Node Resolution with Trio ===
-Resolving: /dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+=== Bootstrap Node Resolution ===
+Resolving: /dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
   Peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-  Resolved to 1 addresses:
-    1. /ip4/140.82.121.4/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+  Resolved to 6 addresses:
+    1. /ip4/139.178.91.71/tcp/4001/p2p/
+      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+    2. /ip4/139.178.91.71/udp/4001/quic-v1/p2p/
+      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+    ... (more addresses)
 
-=== DNS Protocol Comparison with Trio ===
+=== DNS Protocol Comparison ===
 Testing DNS (both IPv4 and IPv6): /dns/example.com
   Resolved to 12 addresses:
     1. /ip4/23.215.0.136
     2. /ip4/23.215.0.138
-    ... (more addresses)
+    ... (6 IPv4 + 6 IPv6 addresses)
 
-=== Peer ID Preservation Test with Trio ===
-Original address: /dnsaddr/example.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+=== Peer ID Preservation Test ===
+Original address: /dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
 Original peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-Resolved to 1 addresses:
-  1. /ip4/23.192.228.80/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+Resolved to 6 addresses:
+  1. /ip4/139.178.91.71/tcp/4001/p2p/
+    QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
      Peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
      Peer ID preserved: True
 
-=== Sequential DNS Resolution with Trio ===
+=== Sequential DNS Resolution ===
 /dns/example.com:
   Resolved to 12 addresses:
     - /ip4/23.215.0.136
@@ -61,12 +66,10 @@ Resolved to 1 addresses:
 
 === py-libp2p Integration Example ===
 Processing bootstrap node: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-  Resolved: 140.82.121.4:None (peer: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN)
+  Resolved: 139.178.91.71:4001 (peer: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN)
 
-Resolved 3 bootstrap peers:
-  QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 140.82.121.4:None
-  QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 104.16.132.229:None
-  QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 142.250.184.206:None
+Resolved 1 bootstrap peers:
+  QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 139.178.91.71:4001
 
 ==================================================
 All examples completed!
@@ -78,7 +81,7 @@ All examples completed!
 - **Peer ID Preservation**: Maintaining peer IDs during resolution
 - **Multiple Protocol Support**: /dns/, /dns4/, /dns6/, /dnsaddr/
 - **Error Handling**: Graceful handling of resolution failures
-- **Real Domain Examples**: Using actual domains that resolve to IP addresses
+- **Real Bootstrap Node Examples**: Using actual libp2p bootstrap nodes that resolve to IP addresses
 
 ## Requirements
 
@@ -95,8 +98,8 @@ python trio_dns_examples.py
 
 ## Notes
 
-- This script uses real domains (github.com, cloudflare.com, google.com) that actually resolve
-- The DNS resolver requires trio (not asyncio) for async operations
+- This script uses real bootstrap nodes from bootstrap.libp2p.io that actually resolve
+- The DNS resolver requires trio for async operations
 - Peer IDs are preserved during resolution for bootstrap node functionality
 - All examples demonstrate working DNS resolution to actual IP addresses
 """
@@ -109,7 +112,7 @@ from multiaddr.resolvers import DNSResolver
 
 async def basic_dns_resolution():
     """
-    Basic DNS resolution example using trio.
+    Basic DNS resolution example.
 
     This function demonstrates the simplest form of DNS resolution:
     - Creates a DNS multiaddr for example.com
@@ -117,7 +120,7 @@ async def basic_dns_resolution():
     - Shows the original and resolved addresses
 
     Expected output:
-    === Basic DNS Resolution with Trio ===
+    === Basic DNS Resolution ===
     Original address: /dns/example.com
     Protocols: ['dns']
     Resolved to 12 addresses:
@@ -126,7 +129,7 @@ async def basic_dns_resolution():
       3. /ip4/23.215.0.138
       ... (more IPv4 and IPv6 addresses)
     """
-    print("=== Basic DNS Resolution with Trio ===")
+    print("=== Basic DNS Resolution ===")
 
     # Test with a simple DNS address
     test_addr = "/dns/example.com"
@@ -146,28 +149,36 @@ async def basic_dns_resolution():
 
 async def bootstrap_node_resolution():
     """
-    Resolve bootstrap node addresses using trio.
+    Resolve bootstrap node addresses.
 
     This function demonstrates resolving real bootstrap node addresses that include peer IDs:
-    - Uses real domains (github.com, cloudflare.com, google.com) that actually resolve
+    - Uses real domains from bootstrap.libp2p.io that actually resolve
     - Shows how peer IDs are preserved during resolution
     - Extracts connection information (IP addresses) from resolved addresses
 
     Expected output:
-    === Bootstrap Node Resolution with Trio ===
-    Resolving: /dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+    === Bootstrap Node Resolution ===
+    Resolving: /dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
       Peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-      Resolved to 1 addresses:
-        1. /ip4/140.82.121.4/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-           Connection: 140.82.121.4:None
+      Resolved to 6 addresses:
+        1. /ip4/139.178.91.71/tcp/4001/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+        2. /ip4/139.178.91.71/udp/4001/quic-v1/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+        3. /ip6/2604:1380:45e3:6e00::1/tcp/4001/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+        4. /ip6/2604:1380:45e3:6e00::1/udp/4001/quic-v1/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+        5. /ip4/139.178.91.71/tcp/443/wss/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+        6. /ip6/2604:1380:45e3:6e00::1/tcp/443/wss/p2p/
+          QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
     """
-    print("\n=== Bootstrap Node Resolution with Trio ===")
+    print("\n=== Bootstrap Node Resolution ===")
 
-    # Real bootstrap addresses that actually resolve to IP addresses
+    # Use only one bootstrap address to reduce repetition
     bootstrap_addresses = [
-        "/dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-        "/dnsaddr/cloudflare.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-        "/dnsaddr/google.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
     ]
 
     resolver = DNSResolver()
@@ -187,7 +198,7 @@ async def bootstrap_node_resolution():
             for i, resolved_ma in enumerate(resolved, 1):
                 print(f"    {i}. {resolved_ma}")
 
-                # Extract IP and port information
+                # Extract IP and port information for TCP connections only
                 ip_addr = None
                 port = None
                 for proto, value in resolved_ma.items():
@@ -205,7 +216,7 @@ async def bootstrap_node_resolution():
 
 async def dns_protocol_comparison():
     """
-    Compare different DNS protocols using trio.
+    Compare different DNS protocols.
 
     This function demonstrates the differences between various DNS protocols:
     - /dns/ - Resolves to both IPv4 and IPv6 addresses
@@ -214,7 +225,7 @@ async def dns_protocol_comparison():
     - /dnsaddr/ - Resolves to both IPv4 and IPv6 addresses (same as /dns/)
 
     Expected output:
-    === DNS Protocol Comparison with Trio ===
+    === DNS Protocol Comparison ===
     Testing DNS (both IPv4 and IPv6): /dns/example.com
       Resolved to 12 addresses:
         1. /ip4/23.215.0.136
@@ -233,13 +244,13 @@ async def dns_protocol_comparison():
         2. /ip6/2600:1406:3a00:21::173e:2e65
         ... (6 IPv6 addresses only)
     """
-    print("\n=== DNS Protocol Comparison with Trio ===")
+    print("\n=== DNS Protocol Comparison ===")
 
     dns_tests = [
         ("/dns/example.com", "DNS (both IPv4 and IPv6)"),
         ("/dns4/example.com", "DNS4 (IPv4 only)"),
         ("/dns6/example.com", "DNS6 (IPv6 only)"),
-        ("/dnsaddr/example.com", "DNSADDR (both IPv4 and IPv6)"),
+        ("/dnsaddr/bootstrap.libp2p.io", "DNSADDR (both IPv4 and IPv6)"),
     ]
 
     resolver = DNSResolver()
@@ -252,8 +263,11 @@ async def dns_protocol_comparison():
             resolved = await resolver.resolve(ma)
 
             print(f"  Resolved to {len(resolved)} addresses:")
-            for i, addr in enumerate(resolved, 1):
+            # Show only first 3 addresses to reduce repetition
+            for i, addr in enumerate(resolved[:3], 1):
                 print(f"    {i}. {addr}")
+            if len(resolved) > 3:
+                print(f"    ... and {len(resolved) - 3} more addresses")
 
         except Exception as e:
             print(f"  Error: {e}")
@@ -269,17 +283,19 @@ async def peer_id_preservation_test():
     - Confirms the peer ID remains unchanged in the resolved addresses
 
     Expected output:
-    === Peer ID Preservation Test with Trio ===
-    Original address: /dnsaddr/example.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+    === Peer ID Preservation Test ===
+    Original address: /dnsaddr/bootstrap.libp2p.io/p2p/
+      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
     Original peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-    Resolved to 1 addresses:
-      1. /ip4/23.192.228.80/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+    Resolved to 6 addresses:
+      1. /ip4/139.178.91.71/tcp/4001/p2p/
+         QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
          Peer ID: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
          Peer ID preserved: True
     """
-    print("\n=== Peer ID Preservation Test with Trio ===")
+    print("\n=== Peer ID Preservation Test ===")
 
-    test_addr = "/dnsaddr/example.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+    test_addr = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
     try:
         ma = Multiaddr(test_addr)
@@ -290,11 +306,15 @@ async def peer_id_preservation_test():
         resolved = await ma.resolve()
 
         print(f"Resolved to {len(resolved)} addresses:")
-        for i, resolved_ma in enumerate(resolved, 1):
+        # Show only first 2 addresses to reduce repetition
+        for i, resolved_ma in enumerate(resolved[:2], 1):
             resolved_peer_id = resolved_ma.get_peer_id()
             print(f"  {i}. {resolved_ma}")
             print(f"     Peer ID: {resolved_peer_id}")
             print(f"     Peer ID preserved: {original_peer_id == resolved_peer_id}")
+
+        if len(resolved) > 2:
+            print(f"  ... and {len(resolved) - 2} more addresses (all with preserved peer ID)")
 
     except Exception as e:
         print(f"Error: {e}")
@@ -309,10 +329,8 @@ async def concurrent_resolution():
     - Handles errors gracefully for each address
     - Shows the results for each resolution attempt
 
-    Note: Uses sequential processing instead of concurrent due to trio version compatibility.
-
     Expected output:
-    === Sequential DNS Resolution with Trio ===
+    === Sequential DNS Resolution ===
     /dns/example.com:
       Resolved to 12 addresses:
         - /ip4/23.215.0.136
@@ -331,13 +349,13 @@ async def concurrent_resolution():
         - /ip6/2600:1406:3a00:21::173e:2e65
         ... (IPv6 addresses only)
     """
-    print("\n=== Sequential DNS Resolution with Trio ===")
+    print("\n=== Sequential DNS Resolution ===")
 
     addresses = [
         "/dns/example.com",
         "/dns4/example.com",
         "/dns6/example.com",
-        "/dnsaddr/example.com",
+        "/dnsaddr/bootstrap.libp2p.io",
     ]
 
     async def resolve_single(addr_str):
@@ -361,13 +379,16 @@ async def concurrent_resolution():
             print(f"  Error: {error}")
         else:
             print(f"  Resolved to {len(resolved)} addresses:")
-            for addr in resolved:
+            # Show only first 3 addresses to reduce repetition
+            for addr in resolved[:3]:
                 print(f"    - {addr}")
+            if len(resolved) > 3:
+                print(f"    ... and {len(resolved) - 3} more addresses")
 
 
 async def py_libp2p_integration_example():
     """
-    Example of how to integrate with py-libp2p using trio.
+    Example of how to integrate with py-libp2p.
 
     This function demonstrates a practical integration pattern for py-libp2p:
     - Resolves real bootstrap node addresses to IP addresses
@@ -378,25 +399,18 @@ async def py_libp2p_integration_example():
     Expected output:
     === py-libp2p Integration Example ===
     Processing bootstrap node: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-      Resolved: 140.82.121.4:None (peer: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN)
+      Resolved: 139.178.91.71:4001 (peer: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN)
 
-    Processing bootstrap node: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
-      Resolved: 104.16.132.229:None (peer: QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN)
-
-    Resolved 3 bootstrap peers:
-      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 140.82.121.4:None
-      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 104.16.132.229:None
-      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 142.250.184.206:None
+    Resolved 1 bootstrap peers:
+      QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN -> 139.178.91.71:4001
     """
     print("\n=== py-libp2p Integration Example ===")
 
     resolver = DNSResolver()
 
-    # Real bootstrap node addresses that actually resolve
+    # Use only one bootstrap address to reduce repetition
     bootstrap_addresses = [
-        "/dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-        "/dnsaddr/cloudflare.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-        "/dnsaddr/google.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
     ]
 
     resolved_peers = []
@@ -443,28 +457,12 @@ async def py_libp2p_integration_example():
     for peer in resolved_peers:
         print(f"  {peer['peer_id']} -> {peer['ip_addr']}:{peer['port']}")
 
-    # Example of how to use with py-libp2p:
-    # ```
-    # from libp2p import Libp2p  # or whatever the actual import is
-    #
-    # async def connect_to_peers():
-    #     node = Libp2p()
-    #
-    #     for peer in resolved_peers:
-    #         try:
-    #             # Connect to the resolved peer using trio
-    #             await node.connect(peer['peer_id'], peer['ip_addr'], peer['port'])
-    #             print(f"Connected to {peer['peer_id']}")
-    #         except Exception as e:
-    #             print(f"Failed to connect to {peer['peer_id']}: {e}")
-    # ```
-
     return resolved_peers
 
 
 async def main():
     """
-    Run all examples using trio.
+    Run all examples.
 
     This function orchestrates all the DNS resolution examples:
     1. Basic DNS resolution
@@ -475,9 +473,9 @@ async def main():
     6. py-libp2p integration example
 
     Each example demonstrates different aspects of DNS resolution functionality
-    and shows how to use it with py-multiaddr and trio.
+    and shows how to use it with py-multiaddr.
     """
-    print("DNS Resolution Examples with Trio")
+    print("DNS Resolution Examples")
     print("=" * 50)
 
     try:
@@ -491,7 +489,7 @@ async def main():
         print("\n" + "=" * 50)
         print("All examples completed!")
         print("\nSummary:")
-        print("- DNS resolution is working correctly with trio")
+        print("- DNS resolution is working correctly")
         print("- Real domains are being resolved to IP addresses")
         print("- Peer IDs are preserved during resolution")
         print("- All DNS protocols (/dns/, /dns4/, /dns6/, /dnsaddr/) are functional")

--- a/examples/dnsaddr/dnsaddr.py
+++ b/examples/dnsaddr/dnsaddr.py
@@ -1,0 +1,53 @@
+import trio
+
+from multiaddr import Multiaddr
+from multiaddr.resolvers import DNSResolver
+
+# Example DNSADDR resolution script
+#
+# Expected output:
+# - Successful resolutions show resolved multiaddrs (e.g., /ip4/139.178.91.71/tcp/4001/p2p/...)
+# - Failed resolutions show "(No resolution results)" (empty list returned)
+# - This matches the JS implementation and libp2p spec behavior
+#
+# Sample output:
+# Resolving: /dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+#   -> /ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+#   -> /ip4/139.178.91.71/udp/4001/quic-v1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+#   ...
+# Resolving: /dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
+#   (No resolution results)
+
+ADDRESSES = [
+    "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+    "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+    "/dnsaddr/bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp",
+    "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+    "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+    "/dnsaddr/github.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+    "/dnsaddr/cloudflare.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+    "/dnsaddr/google.com/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+]
+
+
+async def main():
+    resolver = DNSResolver()
+    for addr in ADDRESSES:
+        print(f"\nResolving: {addr}")
+        ma = Multiaddr(addr)
+        try:
+            resolved = await resolver.resolve(ma)
+            if resolved:
+                for r in resolved:
+                    print(f"  -> {r}")
+            else:
+                # If DNSADDR resolution fails (no TXT records or no matching entries),
+                # the result is an empty list (no resolution results), matching the JS
+                # implementation and spec.
+                print("  (No resolution results)")
+        except Exception as e:
+            print(f"  (Error: {e})")
+
+
+if __name__ == "__main__":
+    trio.run(main)

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -1,3 +1,39 @@
+"""
+Multiaddr Protocol Codes and Registry
+
+This module defines all supported multiaddr protocol codes, their names, and their encodings.
+
+Key features:
+- Protocol code constants (e.g., P_IP4, P_TCP, P_DNSADDR)
+- Protocol class for protocol metadata
+- ProtocolRegistry for fast lookup and aliasing
+- Reference to the multicodec table for protocol codes
+
+Common protocol codes:
+    P_IP4 = 0x04      # IPv4
+    P_IP6 = 0x29      # IPv6
+    P_TCP = 0x06      # TCP
+    P_UDP = 0x0111    # UDP
+    P_DNS = 0x35      # DNS (any)
+    P_DNS4 = 0x36     # DNS (IPv4)
+    P_DNS6 = 0x37     # DNS (IPv6)
+    P_DNSADDR = 0x38  # DNSADDR (libp2p)
+    P_P2P = 0x01A5    # Peer ID
+    P_TLS = 0x01C0    # TLS
+    P_HTTP = 0x01E0   # HTTP
+    P_HTTPS = 0x01BB  # HTTPS
+    ...
+
+For a full list, see the PROTOCOLS list and the multicodec table:
+https://github.com/multiformats/multicodec/blob/master/table.csv
+
+Example usage:
+    from multiaddr.protocols import P_TCP, protocol_with_code
+    print(P_TCP)  # 6
+    proto = protocol_with_code(P_TCP)
+    print(proto.name)  # 'tcp'
+"""
+
 from typing import Any, Optional, Union
 
 import varint

--- a/multiaddr/resolvers/dns.py
+++ b/multiaddr/resolvers/dns.py
@@ -1,11 +1,31 @@
-"""DNS resolver implementation for multiaddr."""
+"""
+DNS resolver implementation for multiaddr.
 
+This module provides DNS resolution for multiaddrs, supporting the following protocols:
+- /dns, /dns4, /dns6: Standard DNS resolution for IPv4 and IPv6
+- /dnsaddr: Recursive TXT record resolution for libp2p bootstrap nodes
+
+Features:
+- Recursive resolution for /dnsaddr, /dns4, and /dns6
+- Peer ID preservation during resolution
+- Timeout and cancellation support (Trio)
+- Error handling for recursion limits and DNS failures
+
+Example usage:
+    from multiaddr import Multiaddr
+    ma = Multiaddr("/dns4/example.com/tcp/443")
+    resolved = await ma.resolve()
+    print(resolved)
+    # [Multiaddr("/ip4/93.184.216.34/tcp/443")]
+"""
+
+import logging
 import re
 from typing import Optional, cast
 
-import base58
 import dns.asyncresolver
 import dns.rdataclass
+import dns.rdtypes.ANY.TXT  # type: ignore
 import dns.rdtypes.IN.A
 import dns.rdtypes.IN.AAAA
 import dns.resolver
@@ -18,7 +38,13 @@ from .base import Resolver
 
 
 class DNSResolver(Resolver):
-    """DNS resolver for multiaddr."""
+    """
+    DNS resolver for multiaddr.
+
+    Resolves /dns, /dns4, /dns6, and /dnsaddr multiaddrs to their underlying IP addresses.
+    Supports recursive resolution for DNSADDR records and protocol-specific resolution for
+    DNS4/DNS6.
+    """
 
     MAX_RECURSIVE_DEPTH = 32
     DEFAULT_TIMEOUT = 5.0  # 5 seconds timeout
@@ -30,11 +56,12 @@ class DNSResolver(Resolver):
     async def resolve(
         self, maddr: "Multiaddr", options: Optional[dict] = None
     ) -> list["Multiaddr"]:
-        """Resolve a DNS multiaddr to its actual addresses.
+        """
+        Resolve a DNS multiaddr to its actual addresses.
 
         Args:
             maddr: The multiaddr to resolve
-            options: Optional configuration options
+            options: Optional configuration options (e.g., max_recursive_depth, signal)
 
         Returns:
             A list of resolved multiaddrs
@@ -63,7 +90,8 @@ class DNSResolver(Resolver):
         # Get max recursive depth from options or use default
         max_depth = (
             options.get("max_recursive_depth", self.MAX_RECURSIVE_DEPTH)
-            if options else self.MAX_RECURSIVE_DEPTH
+            if options
+            else self.MAX_RECURSIVE_DEPTH
         )
 
         # Get signal from options if provided
@@ -77,10 +105,10 @@ class DNSResolver(Resolver):
                     max_depth,
                     signal,
                 )
-                return resolved if resolved else [maddr]
+                return resolved  # Do not fallback to [maddr]
             else:
-                resolved = await self._resolve_dns(hostname, first_protocol.code, signal)
-                return resolved if resolved else [maddr]
+                resolved = await self._resolve_dns_with_stack(maddr, signal)
+                return resolved if resolved else [maddr]  # Classic DNS fallback remains
         except RecursionLimitError:
             # Do not wrap RecursionLimitError so tests can catch it
             raise
@@ -106,7 +134,11 @@ class DNSResolver(Resolver):
         max_depth: int,
         signal: Optional[trio.CancelScope] = None,
     ) -> list["Multiaddr"]:
-        """Resolve a DNSADDR record.
+        """
+        Resolve a DNSADDR record according to libp2p specification.
+
+        Queries TXT records from _dnsaddr.<hostname> and parses dnsaddr=<multiaddr> entries.
+        Recursively resolves /dns4 and /dns6 entries to /ip4 and /ip6 addresses.
 
         Args:
             hostname: The hostname to resolve
@@ -133,43 +165,16 @@ class DNSResolver(Resolver):
             # If there's no peer ID, that's fine - we'll just resolve the address
             pass
 
-        # Resolve the hostname with timeout and cancellation support
+        # Query TXT records from _dnsaddr.<hostname> according to libp2p spec
+        dnsaddr_hostname = f"_dnsaddr.{hostname}"
+
         try:
             if signal:
                 # Use the provided signal for cancellation
                 with signal:
-                    results = []
-                    # Try both A and AAAA records
-                    for record_type, fam in [("A", "ip4"), ("AAAA", "ip6")]:
-                        try:
-                            answer = await self._resolver.resolve(hostname, record_type)
-                            for rdata in answer:
-                                # Cast to the specific DNS record type to access address
-                                if record_type == "A":
-                                    address = str(cast(dns.rdtypes.IN.A.A, rdata).address)
-                                else:  # AAAA
-                                    address = str(cast(dns.rdtypes.IN.AAAA.AAAA, rdata).address)
-                                ma = Multiaddr(f"/{fam}/{address}")
-                                def is_valid_peer_id(peer_id):
-                                    try:
-                                        decoded = base58.b58decode(peer_id)
-                                        if len(decoded) in (34, 36, 38, 42, 46):
-                                            return True
-                                    except Exception:
-                                        pass
-                                    if peer_id.startswith(("b", "z")) and len(peer_id) > 40:
-                                        return True
-                                    return False
-                                if peer_id and is_valid_peer_id(peer_id):
-                                    try:
-                                        ma = ma.encapsulate(f"/p2p/{peer_id}")
-                                        return [ma]
-                                    except Exception:
-                                        continue
-                                results.append(ma)
-                        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                            continue
-                    return results
+                    return await self._query_dnsaddr_txt_records(
+                        dnsaddr_hostname, peer_id, max_depth, signal
+                    )
             else:
                 # Use default timeout-based cancellation
                 with trio.CancelScope() as cancel_scope:  # type: ignore[call-arg]
@@ -177,40 +182,104 @@ class DNSResolver(Resolver):
                     cancel_scope.deadline = trio.current_time() + self.DEFAULT_TIMEOUT
                     cancel_scope.cancelled_caught = True
 
-                    results = []
-                    # Try both A and AAAA records
-                    for record_type, fam in [("A", "ip4"), ("AAAA", "ip6")]:
-                        try:
-                            answer = await self._resolver.resolve(hostname, record_type)
-                            for rdata in answer:
-                                # Cast to the specific DNS record type to access address
-                                if record_type == "A":
-                                    address = str(cast(dns.rdtypes.IN.A.A, rdata).address)
-                                else:  # AAAA
-                                    address = str(cast(dns.rdtypes.IN.AAAA.AAAA, rdata).address)
-                                ma = Multiaddr(f"/{fam}/{address}")
-                                def is_valid_peer_id(peer_id):
-                                    try:
-                                        decoded = base58.b58decode(peer_id)
-                                        if len(decoded) in (34, 36, 38, 42, 46):
-                                            return True
-                                    except Exception:
-                                        pass
-                                    if peer_id.startswith(("b", "z")) and len(peer_id) > 40:
-                                        return True
-                                    return False
-                                if peer_id and is_valid_peer_id(peer_id):
-                                    try:
-                                        ma = ma.encapsulate(f"/p2p/{peer_id}")
-                                        return [ma]
-                                    except Exception:
-                                        continue
-                                results.append(ma)
-                        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                            continue
-                    return results
+                    return await self._query_dnsaddr_txt_records(
+                        dnsaddr_hostname, peer_id, max_depth, cancel_scope
+                    )
         except Exception as e:
             raise ResolutionError(f"Failed to resolve DNSADDR {hostname}: {e!s}")
+
+    async def _query_dnsaddr_txt_records(
+        self,
+        dnsaddr_hostname: str,
+        peer_id: Optional[str],
+        max_depth: int,
+        signal: Optional[trio.CancelScope] = None,
+        _debug_level: int = 0,
+    ) -> list["Multiaddr"]:
+        """
+        Query TXT records and parse dnsaddr=<multiaddr> entries.
+
+        Args:
+            dnsaddr_hostname: The _dnsaddr.<hostname> to query
+            peer_id: Optional peer ID to filter results
+            max_depth: Maximum depth for recursive resolution
+            signal: Optional signal for cancellation
+            _debug_level: Internal, for debug output indentation
+
+        Returns:
+            A list of resolved multiaddrs
+        """
+        results = []
+        indent = "  " * _debug_level
+        try:
+            answer = await self._resolver.resolve(dnsaddr_hostname, "TXT")
+            logging.debug(
+                f"{indent}Queried TXT for {dnsaddr_hostname}, "
+                f"found {len(answer)} records (depth {max_depth})"
+            )
+            for rdata in answer:
+                # Cast to TXT record type for proper attribute access
+                txt_rdata = cast(dns.rdtypes.ANY.TXT.TXT, rdata)
+                txt_data_raw = txt_rdata.strings[0] if txt_rdata.strings else ""
+                if isinstance(txt_data_raw, bytes):
+                    txt_data = txt_data_raw.decode("utf-8")
+                else:
+                    txt_data = str(txt_data_raw)
+                logging.debug(f"{indent}  TXT: {txt_data}")
+                if txt_data.startswith("dnsaddr="):
+                    multiaddr_str = txt_data[8:]
+                    multiaddr_str = self._clean_quotes(multiaddr_str).strip()
+                    logging.debug(f"{indent}    Parsed multiaddr: {multiaddr_str}")
+                    if not multiaddr_str:
+                        continue
+                    try:
+                        parsed_ma = Multiaddr(multiaddr_str)
+                        try:
+                            parsed_peer_id = parsed_ma.get_peer_id()
+                            logging.debug(f"{indent}      Peer ID: {parsed_peer_id}")
+                        except Exception:
+                            logging.debug(f"{indent}      No peer ID")
+                        if peer_id:
+                            try:
+                                parsed_peer_id = parsed_ma.get_peer_id()
+                                if parsed_peer_id != peer_id:
+                                    logging.debug(f"{indent}      Skipping (peer ID mismatch)")
+                                    continue
+                            except Exception:
+                                logging.debug(f"{indent}      Skipping (no peer ID in multiaddr)")
+                                continue
+                        if (
+                            multiaddr_str.startswith("/dnsaddr")
+                            or multiaddr_str.startswith("/dns4")
+                            or multiaddr_str.startswith("/dns6")
+                        ):
+                            try:
+                                logging.debug(f"{indent}      Recursing into {multiaddr_str}")
+                                recursive_options = {"max_recursive_depth": max_depth - 1}
+                                resolved = await self.resolve(parsed_ma, recursive_options)
+                                for r in resolved:
+                                    # Only append if not a dnsaddr/dns4/dns6 (i.e., only final IPs)
+                                    if not any(
+                                        p.name in ("dnsaddr", "dns4", "dns6") for p in r.protocols()
+                                    ):
+                                        logging.debug(f"{indent}        Final resolved: {r}")
+                                        results.append(r)
+                            except RecursionLimitError:
+                                logging.debug(f"{indent}      Recursion limit hit!")
+                                continue
+                        else:
+                            logging.debug(f"{indent}      Final resolved: {parsed_ma}")
+                            results.append(parsed_ma)
+                    except Exception as e:
+                        logging.debug(f"{indent}      Error parsing multiaddr: {e}")
+                        continue
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+            logging.debug(f"{indent}No TXT records found for {dnsaddr_hostname}")
+            pass
+        except Exception as e:
+            logging.debug(f"{indent}Error querying TXT records for {dnsaddr_hostname}: {e}")
+            raise ResolutionError(f"Failed to query TXT records for {dnsaddr_hostname}: {e!s}")
+        return results
 
     async def _resolve_dns(
         self, hostname: str, protocol_code: int, signal: Optional[trio.CancelScope] = None
@@ -273,6 +342,67 @@ class DNSResolver(Resolver):
                 return results
         except Exception as e:
             raise ResolutionError(f"Failed to resolve DNS {hostname}: {e!s}")
+
+    async def _resolve_dns_with_stack(
+        self, maddr: "Multiaddr", signal: Optional[trio.CancelScope] = None
+    ) -> list["Multiaddr"]:
+        """Resolve a DNS record while preserving the rest of the multiaddr stack.
+
+        This method handles cases like /dns4/host/tcp/port by resolving the DNS part
+        and keeping the rest of the multiaddr intact.
+
+        Args:
+            maddr: The multiaddr to resolve
+            signal: Optional signal for cancellation
+
+        Returns:
+            A list of resolved multiaddrs with preserved stack
+
+        Raises:
+            ResolutionError: If resolution fails
+            trio.Cancelled: If the operation is cancelled
+        """
+        protocols = list(maddr.protocols())
+        if not protocols:
+            return [maddr]
+
+        first_protocol = protocols[0]
+        if first_protocol.code not in (P_DNS, P_DNS4, P_DNS6):
+            return [maddr]
+
+        # Get the hostname
+        hostname = maddr.value_for_protocol(first_protocol.code)
+        if not hostname:
+            return [maddr]
+
+        # Remove quotes from hostname
+        hostname = self._clean_quotes(hostname)
+
+        # Get the resolved IP addresses
+        resolved_ips = await self._resolve_dns(hostname, first_protocol.code, signal)
+        if not resolved_ips:
+            return [maddr]
+
+        # Split the multiaddr to get the remaining stack (everything after the DNS part)
+        parts = maddr.split(1)  # Split after the first protocol
+        if len(parts) < 2:
+            # No remaining stack, just return the resolved IPs
+            return resolved_ips
+
+        remaining_stack = parts[1]  # Everything after the DNS part
+
+        results = []
+        for ip_maddr in resolved_ips:
+            # Combine the resolved IP with the remaining stack
+            if remaining_stack.protocols():
+                # There's a remaining stack, encapsulate it
+                combined = ip_maddr.encapsulate(remaining_stack)
+            else:
+                # No remaining stack, just use the IP
+                combined = ip_maddr
+            results.append(combined)
+
+        return results
 
 
 __all__ = ["DNSResolver"]

--- a/newsfragments/80.feature.rst
+++ b/newsfragments/80.feature.rst
@@ -1,0 +1,1 @@
+Added full support for dnsaddr protocol and dns4 and dns6 as well

--- a/newsfragments/80.internal.rst
+++ b/newsfragments/80.internal.rst
@@ -1,0 +1,1 @@
+Added full tests and doc. All typecheck passes


### PR DESCRIPTION
# feat: add full dnsaddr, dns4, dns6 protocols and examples and docs

## Summary

This commit introduces comprehensive support for DNS-based multiaddr protocols and significantly improves the documentation and examples for the library.

## Key Changes

- **Full support for `/dnsaddr`, `/dns4`, and `/dns6` protocols**
  - Recursive resolution for `/dnsaddr` records, including peer ID preservation
  - Proper resolution for `/dns4` and `/dns6` to `/ip4` and `/ip6` addresses
  - Improved error handling and recursion limits in DNS resolver

- **Examples**
  - Added and updated examples for DNSADDR, DNS4, DNS6, and thin waist address validation
  - New comprehensive example for `decapsulate_code` usage
  - All examples are now referenced in the documentation and are runnable

- **Documentation**
  - Major overhaul of Sphinx docs:
    - Enhanced `index.rst` with a clear introduction, features, protocols, and use cases
    - Added a dedicated `examples.rst` with categorized, practical code examples
    - Improved docstrings in resolver and protocol modules for better API documentation
    - Installation instructions clarified and deduplicated
    - Removed redundant quick start/code snippets from the index page
  - All documentation now follows a clear, non-redundant structure

- **Code Quality**
  - All files are compliant with ruff/PEP8 (line length, formatting, etc.)
  - Improved comments and docstrings for maintainability

## Impact

- Users can now resolve `/dnsaddr`, `/dns4`, and `/dns6` multiaddrs reliably
- Examples and documentation are much easier to follow and up to date
- The codebase is cleaner and more maintainable

---

This commit brings the library up to date with modern multiaddr usage, especially for libp2p and distributed systems, and makes it much more accessible for new users and contributors. 