### PR TITLE
dep: changed py-cid to github acul71/py-cid-fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "idna",
     "netaddr",
     "psutil",
-    "py-cid",
+    "py-cid @ git+https://github.com/acul71/py-cid-fork.git",
     "py-multicodec >= 0.2.0",
     "trio-typing>=0.0.4",
     "trio>=0.26.0",


### PR DESCRIPTION
changed py-cid to github acul71/py-cid-fork
The fork is using pymultihash instead of py-multihash (older)
This resolve some issues with py-libp2p that uses py-multihash