### PR TITLE
WIP: Add missing protocols in reference with go-multiaddr

### DIFF
--- a/multiaddr/codecs/http_path.py
+++ b/multiaddr/codecs/http_path.py
@@ -5,7 +5,7 @@ from urllib.parse import quote, unquote
 from ..codecs import CodecBase
 from ..exceptions import BinaryParseError, StringParseError
 
-IS_PATH = True
+IS_PATH = False
 SIZE = -1  # LengthPrefixedVarSize
 
 

--- a/multiaddr/codecs/http_path.py
+++ b/multiaddr/codecs/http_path.py
@@ -46,4 +46,3 @@ class Codec(CodecBase):
         """
         if len(b) == 0:
             raise ValueError("Empty http path is not allowed")
-

--- a/multiaddr/codecs/http_path.py
+++ b/multiaddr/codecs/http_path.py
@@ -1,0 +1,49 @@
+from typing import Any
+from urllib.parse import quote, unquote
+
+from ..codecs import CodecBase
+from ..exceptions import BinaryParseError
+
+IS_PATH = True
+SIZE = -1  # LengthPrefixedVarSize
+
+
+class Codec(CodecBase):
+    SIZE = SIZE
+    IS_PATH = IS_PATH
+
+    def to_bytes(self, proto: Any, string: str) -> bytes:
+        """
+        Convert an HTTP path string to bytes
+        Unescape URL-encoded characters, validated non-empty, then encode
+        as UTF-8
+        """
+
+        try:
+            unescaped = unquote(string)
+        except Exception:
+            raise ValueError(f"Invalid HTTP path string: {string}")
+
+        if len(unescaped) == 0:
+            raise ValueError("empty http path is not allowed")
+
+        return unescaped.encode("utf-8")
+
+    def to_string(self, proto: Any, buf: bytes) -> str:
+        """
+        Convert bytes to an HTTP path string
+        Encode as UTTF-8 and URL-escape
+        """
+        if len(buf) == 0:
+            raise BinaryParseError("Empty http path is not allowed", buf, "http-path")
+
+        return quote(buf.decode("utf-8"))
+
+    def validate(self, b: bytes) -> None:
+        """
+        Validate an HTTP path buffer.
+        Just check non-empty.
+        """
+        if len(b) == 0:
+            raise ValueError("Empty http path is not allowed")
+

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -354,12 +354,12 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
                 continue
 
             # Special handling for unix paths
-            if part == "unix":
+            if part in ("unix", "http-path"):
                 try:
                     # Get the next part as the path value
-                    unix_path_value = next(parts)
-                    if not unix_path_value:
-                        raise exceptions.StringParseError("empty unix path", addr)
+                    protocol_path_value = next(parts)
+                    if not protocol_path_value:
+                        raise exceptions.StringParseError("empty protocol path", addr)
 
                     # Join any remaining parts as part of the path
                     remaining_parts = []
@@ -373,16 +373,16 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
                             break
 
                     if remaining_parts:
-                        unix_path_value = unix_path_value + "/" + "/".join(remaining_parts)
+                        protocol_path_value = protocol_path_value + "/" + "/".join(remaining_parts)
 
-                    proto = protocol_with_name("unix")
+                    proto = protocol_with_name(part)
                     codec = codec_by_name(proto.codec)
                     if not codec:
                         raise exceptions.StringParseError(f"unknown codec: {proto.codec}", addr)
 
                     try:
                         self._bytes += varint.encode(proto.code)
-                        buf = codec.to_bytes(proto, unix_path_value)
+                        buf = codec.to_bytes(proto, protocol_path_value)
                         # Add length prefix for variable-sized or zero-sized codecs
                         if codec.SIZE <= 0:
                             self._bytes += varint.encode(len(buf))

--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -354,7 +354,7 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
                 continue
 
             # Special handling for unix paths
-            if part in ("unix", "http-path"):
+            if part in ("unix",):
                 try:
                     # Get the next part as the path value
                     protocol_path_value = next(parts)

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -158,7 +158,7 @@ PROTOCOLS = [
     Protocol(P_QUIC1, "quic-v1", None),
     Protocol(P_HTTP, "http", None),
     Protocol(P_HTTPS, "https", None),
-    Protocol(P_HTTP_PATH, "http-path", None),
+    Protocol(P_HTTP_PATH, "http-path", "http_path"),
     Protocol(P_TLS, "tls", None),
     Protocol(P_WS, "ws", None),
     Protocol(P_WSS, "wss", None),

--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -158,6 +158,7 @@ PROTOCOLS = [
     Protocol(P_QUIC1, "quic-v1", None),
     Protocol(P_HTTP, "http", None),
     Protocol(P_HTTPS, "https", None),
+    Protocol(P_HTTP_PATH, "http-path", None),
     Protocol(P_TLS, "tls", None),
     Protocol(P_WS, "ws", None),
     Protocol(P_WSS, "wss", None),

--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -27,9 +27,9 @@ def string_to_bytes(string: str) -> bytes:
         logger.debug(f"[DEBUG string_to_bytes] Encoded protocol code: {encoded_code}")
         bs.append(encoded_code)
 
-        # Special case: protocols with codec=None are flag protocols
+        # Special case: protocols with codec=None or SIZE=0 are flag protocols
         # (no value, no length prefix, no buffer)
-        if codec is None:
+        if codec is None or getattr(codec, "SIZE", None) == 0:
             logger.debug(
                 f"[DEBUG string_to_bytes] Protocol {proto.name} has no data, "
                 "skipping value encoding"

--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -93,6 +93,7 @@ def bytes_to_string(buf: bytes) -> str:
                     value = codec.to_string(proto, bs.read(size))
                 logger.debug(f"[DEBUG] bytes_to_string: proto={proto.name}, value='{value}'")
                 if codec.IS_PATH and value.startswith("/"):
+                    # For path protocols, the codec already handles URL encoding
                     strings.append("/" + proto.name + value)  # type: ignore[arg-type]
                 else:
                     strings.append("/" + proto.name + "/" + value)  # type: ignore[arg-type]

--- a/newsfragments/94.feature.rst
+++ b/newsfragments/94.feature.rst
@@ -1,0 +1,1 @@
+Added the http-path protocol in reference with go-multiaddr.

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -832,8 +832,8 @@ def test_http_path_multiaddr_roundtrip():
     """Test basic http-path in multiaddr string roundtrip"""
     test_cases = [
         "/http-path/foo",
-        "/http-path/foo/bar",
-        "/http-path/api/v1/users",
+        "/http-path/foo%2Fbar",  # URL-encoded forward slashes
+        "/http-path/api%2Fv1%2Fusers",  # URL-encoded forward slashes
     ]
 
     for addr_str in test_cases:
@@ -848,10 +848,16 @@ def test_http_path_multiaddr_roundtrip():
 def test_http_path_url_encoding():
     """Test special characters and URL encoding behavior"""
     test_cases = [
-        ("/foo bar", "/foo%20bar"),
-        ("/path/with/special!@#", "/path/with/special%21%40%23"),
-        ("/こんにちは", "/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF"),
-        ("/tmp/bar", "/tmp%2Fbar"),  # Forward slash encoding
+        ("/foo%20bar", "/foo%20bar"),  # Already URL-encoded input
+        (
+            "/path%2Fwith%2Fspecial%21%40%23",
+            "/path%2Fwith%2Fspecial%21%40%23",
+        ),  # Already URL-encoded input
+        (
+            "/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF",
+            "/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF",
+        ),  # Already URL-encoded input
+        ("/tmp%2Fbar", "/tmp%2Fbar"),  # Already URL-encoded input
     ]
 
     for input_path, expected_encoded in test_cases:
@@ -864,8 +870,8 @@ def test_http_path_url_encoding():
 def test_http_path_in_complex_multiaddr():
     """Test http-path as part of larger multiaddr chains"""
     test_cases = [
-        ("/ip4/127.0.0.1/tcp/443/tls/http/http-path/api/v1", "api/v1"),
-        ("/ip4/127.0.0.1/tcp/80/http/http-path/static/css", "static/css"),
+        ("/ip4/127.0.0.1/tcp/443/tls/http/http-path/api%2Fv1", "api%2Fv1"),
+        ("/ip4/127.0.0.1/tcp/80/http/http-path/static%2Fcss", "static%2Fcss"),
         ("/dns/example.com/tcp/443/tls/http/http-path/docs", "docs"),
     ]
 
@@ -898,8 +904,8 @@ def test_http_path_value_extraction():
     """Test extracting http-path values from multiaddr"""
     test_cases = [
         ("/http-path/foo", "foo"),
-        ("/http-path/foo/bar", "foo/bar"),
-        ("/http-path/api/v1/users", "api/v1/users"),
+        ("/http-path/foo%2Fbar", "foo%2Fbar"),
+        ("/http-path/api%2Fv1%2Fusers", "api%2Fv1%2Fusers"),
         ("/ip4/127.0.0.1/tcp/80/http/http-path/docs", "docs"),
     ]
 
@@ -912,12 +918,12 @@ def test_http_path_value_extraction():
 def test_http_path_edge_cases():
     """Test edge cases and special character handling"""
 
-    # Test with various special characters
+    # Test with various special characters (URL-encoded input)
     special_paths = [
-        "path with spaces",
-        "path/with/multiple/slashes",
-        "path/with/unicode/测试",
-        "path/with/symbols!@#$%^&*()",
+        "path%20with%20spaces",
+        "path%2Fwith%2Fmultiple%2Fslashes",
+        "path%2Fwith%2Funicode%2F%E6%B5%8B%E8%AF%95",
+        "path%2Fwith%2Fsymbols%21%40%23%24%25%5E%26%2A%28%29",
     ]
 
     for path in special_paths:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -269,3 +269,4 @@ def test_memory_integration_invalid_values():
     # Too large (overflow > uint64)
     with pytest.raises(ValueError):
         Multiaddr(f"/memory/{2**64}")
+

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -274,15 +274,16 @@ def test_memory_integration_invalid_values():
 def test_http_path_bytes_string_roundtrip():
     codec = http_path.Codec()
 
-    # some valid HTTP path strings
+    # some valid HTTP path strings (URL-encoded input as expected by multiaddr system)
+    from urllib.parse import quote
+
     for s in ["/foo", "/foo/bar", "/a b", "/こんにちは", "/path/with/special!@#"]:
-        b = codec.to_bytes(None, s)
+        encoded_s = quote(s, safe="")  # Use same encoding as codec
+        b = codec.to_bytes(None, encoded_s)
         assert isinstance(b, bytes)
         out = codec.to_string(None, b)
-        # URL-escaped roundtrip should match quote/unquote behavior
-        from urllib.parse import quote
-
-        assert out == quote(s)
+        # Should return the same URL-encoded string
+        assert out == encoded_s
 
 
 def test_http_path_empty_string_raises():
@@ -300,10 +301,12 @@ def test_http_path_empty_bytes_raises():
 def test_http_path_special_characters():
     codec = http_path.Codec()
     path = "/foo bar/あいうえお"
-    b = codec.to_bytes(None, path)
     from urllib.parse import quote
 
-    assert codec.to_string(None, b) == quote(path)
+    encoded_path = quote(path, safe="")  # Use same encoding as codec
+    b = codec.to_bytes(None, encoded_path)
+
+    assert codec.to_string(None, b) == encoded_path
 
 
 def test_http_path_validate_function():


### PR DESCRIPTION
Tracks https://github.com/multiformats/multiaddr/issues/181

This is a WIP PR, which aims to add the remaining protocols in py-libp2p in reference with go-libp2p as mentioned in the above issue.

Protocols added in this PR:
- http-path

More protocols to be added in the same in future commits.