### PR TITLE
Add sni protocol in py-multiaddr

### DIFF
--- a/multiaddr/protocols.py
+++ b/multiaddr/protocols.py
@@ -150,6 +150,7 @@ PROTOCOLS = [
     Protocol(P_DNS4, "dns4", "domain"),
     Protocol(P_DNS6, "dns6", "domain"),
     Protocol(P_DNSADDR, "dnsaddr", "domain"),
+    Protocol(P_SNI, "sni", "domain"),
     Protocol(P_SCTP, "sctp", "uint16be"),
     Protocol(P_UDT, "udt", None),
     Protocol(P_UTP, "utp", None),

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -105,6 +105,7 @@ def test_invalid(addr_str):
         "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
         "/dns/example.com",
         "/dns4/موقع.وزارة-الاتصالات.مصر",
+        "/ip4/127.0.0.1/tcp/443/tls/sni/example.com/http/http-path/foo",
     ],
 )  # nopep8
 def test_valid(addr_str):


### PR DESCRIPTION
Added sni protocol in py-multiaddr in reference with go-multiaddr

SNI had the same codec configs as DNS in go-multiaddr
```go
protoSNI = Protocol{
	Name:       "sni",
	Size:       LengthPrefixedVarSize,
	Code:       P_SNI,
	VCode:      CodeToVarint(P_SNI),
	Transcoder: TranscoderDns,
}
```

So just added this line in the protocol registry
```py
Protocol(P_SNI, "sni", "domain"),
```