### PR TITLE
fix: correct decapsulate for repeated protocols and substring collisions

### DIFF
--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -240,12 +240,32 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
         For example:
             /ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
         """
-        addr_str = str(addr)
-        s = str(self)
-        i = s.rindex(addr_str)
-        if i < 0:
-            raise ValueError(f"Address {s} does not contain subaddress: {addr_str}")
-        return Multiaddr(s[:i])
+        other = Multiaddr(addr) if not isinstance(addr, Multiaddr) else addr
+        other_components = list(bytes_iter(other.to_bytes()))
+        self_components = list(bytes_iter(self._bytes))
+
+        last_match_end = -1
+        for i in range(len(self_components)):
+            match = True
+            for j, (_, proto, _, value) in enumerate(other_components):
+                if i + j >= len(self_components):
+                    match = False
+                    break
+                _, s_proto, _, s_value = self_components[i + j]
+                if s_proto != proto or s_value != value:
+                    match = False
+                    break
+
+            if match:
+                last_match_end = self_components[i][0]  # byte offset
+
+        if last_match_end < 0:
+            raise ValueError(f"Address {self} does not contain subaddress: {addr}")
+
+        if last_match_end == 0:
+            return Multiaddr("")
+
+        return Multiaddr(self._bytes[:last_match_end])
 
     def decapsulate_code(self, code: int) -> "Multiaddr":
         """

--- a/newsfragments/109.bugfix
+++ b/newsfragments/109.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where decapsulate produced incorrect results for repeated protocols and substring collisions.

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -613,6 +613,21 @@ def test_decapsulate():
     u = Multiaddr("/udp/1234")
     assert a.decapsulate(u) == Multiaddr("/ip4/127.0.0.1")
 
+    # Issue #109 Case 1 — Repeated protocol
+    ma1 = Multiaddr("/ip4/1.2.3.4/tcp/80/ip4/5.6.7.8/tcp/443")
+    assert ma1.decapsulate("/ip4/5.6.7.8") == Multiaddr("/ip4/1.2.3.4/tcp/80")
+
+    # Issue #109 Case 2 — Substring collision
+    ma2 = Multiaddr("/dns4/example.com/tcp/80")
+    import pytest
+
+    with pytest.raises(ValueError, match="does not contain subaddress"):
+        ma2.decapsulate("/tcp/8")
+
+    # Issue #109 Case 3 — Value contains protocol name
+    ma3 = Multiaddr("/dns4/tcp.example.com/tcp/80")
+    assert ma3.decapsulate("/tcp/80") == Multiaddr("/dns4/tcp.example.com")
+
 
 def test__repr():
     a = Multiaddr("/ip4/127.0.0.1/udp/1234")


### PR DESCRIPTION
Fixes #109

## Description
This pull request fixes a bug where `Multiaddr.decapsulate()` produced incorrect results when the same protocol appears multiple times in the address, or when the decapsulation target is a substring of a protocol value. The implementation has been updated to compare addresses component-by-component using `bytes_iter()` instead of performing a raw string search.

## Changes
- Updated `Multiaddr.decapsulate` in `multiaddr/multiaddr.py` to match components iteratively instead of using `str.rindex()`.
- Added tests to `tests/test_multiaddr.py` containing edge cases for:
  - Repeated protocols
  - Substring collisions
  - Protocol value collisions
- Added a towncrier newsfragment `newsfragments/109.bugfix`.