### PR TITLE
fix: validate binary input in _from_bytes()

### DIFF
--- a/multiaddr/multiaddr.py
+++ b/multiaddr/multiaddr.py
@@ -508,6 +508,24 @@ class Multiaddr(collections.abc.Mapping[Any, Any]):
             self._bytes = b""
             return
 
+        # Validate by iterating all components
+        consumed = 0
+        try:
+            for offset, proto, codec, part_value in bytes_iter(addr):
+                consumed = offset + len(proto.vcode)
+                if codec.SIZE < 0:
+                    consumed += len(varint.encode(len(part_value)))
+                consumed += len(part_value)
+        except Exception as e:
+            raise exceptions.BinaryParseError(f"invalid multiaddr bytes: {e}", addr, 0) from e
+
+        if consumed != len(addr):
+            raise exceptions.BinaryParseError(
+                f"unexpected extra data: {len(addr) - consumed} bytes leftover",
+                addr,
+                0,
+            )
+
         self._bytes = addr
 
     def get_peer_id(self) -> str | None:

--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -172,4 +172,11 @@ def bytes_iter(buf: bytes) -> Generator[tuple[int, Protocol, CodecBase, bytes], 
             ) from exc
 
         size = size_for_addr(codec, buf_io)
-        yield offset, proto, codec, buf_io.read(size)
+        part = buf_io.read(size)
+        if len(part) != size:
+            raise exceptions.BinaryParseError(
+                f"unexpected end of data for protocol {proto.name if proto else code}",
+                buf,
+                proto.name if proto else code,
+            )
+        yield offset, proto, codec, part

--- a/newsfragments/110.bugfix
+++ b/newsfragments/110.bugfix
@@ -1,0 +1,1 @@
+Add validation to Multiaddr initialization from bytes to reject invalid sequences immediately

--- a/tests/test_multiaddr.py
+++ b/tests/test_multiaddr.py
@@ -588,7 +588,19 @@ def test_bad_initialization_too_many_params():
 
 def test_bad_initialization_wrong_type():
     with pytest.raises(TypeError):
-        Multiaddr(42)  # type: ignore
+        Multiaddr(1)  # type: ignore
+
+
+def test_invalid_bytes():
+    from multiaddr.exceptions import BinaryParseError
+
+    # These all should fail immediately when initializing from bytes:
+    with pytest.raises(BinaryParseError):
+        Multiaddr(b"\xff\xff\xff")  # Invalid varint
+    with pytest.raises(BinaryParseError):
+        Multiaddr(b"\x99\x01\x00")  # Unknown protocol code 0x99
+    with pytest.raises(BinaryParseError):
+        Multiaddr(b"\x04\x04\x01\x02")  # ip4 with only 3 bytes of address (needs 4)
 
 
 def test_value_for_protocol_argument_wrong_type():


### PR DESCRIPTION
Fixes #110

## Description
This pull request adds strict validation to the binary multiaddr parser. It updates `_from_bytes()` to parse components iteratively using `bytes_iter()`, ensuring invalid bytes are rejected immediately upon initialization rather than failing later during conversion. It also updates `bytes_iter()` to catch truncated streams.

## Changes
- Updated `Multiaddr._from_bytes()` to validate raw binary components fully and raise a `BinaryParseError` upon encountering unexpected bytes.
- Updated `bytes_iter()` to raise a `BinaryParseError` if a component's byte length is shorter than expected.
- Added `test_invalid_bytes()` to `tests/test_multiaddr.py` to test various invalid multiaddr byte strings.
- Added a towncrier newsfragment `newsfragments/110.bugfix`.