### PR TITLE
fix: handle path protocols correctly in string_iter()

### DIFF
--- a/multiaddr/transforms.py
+++ b/multiaddr/transforms.py
@@ -145,8 +145,13 @@ def string_iter(
                 raise exceptions.StringParseError(
                     f"missing value for protocol: {proto_name}", string
                 )
-            value = parts[i + 1]
-            i += 1  # Skip the next part since we used it as value
+
+            if getattr(codec, "IS_PATH", False):
+                value = "/".join(parts[i + 1 :])
+                i = len(parts) - 1
+            else:
+                value = parts[i + 1]
+                i += 1  # Skip the next part since we used it as value
             logger.debug(f"[DEBUG string_iter] Using next part as value: {value}")
             yield proto, codec, value
         else:

--- a/newsfragments/112.bugfix
+++ b/newsfragments/112.bugfix
@@ -1,0 +1,1 @@
+Fix `string_iter` to correctly handle unix paths and other path protocols by consuming remaining components

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -234,3 +234,13 @@ def test_codec_to_string_value_error(proto, buf):
 )
 def test_cid_autoconvert_to_string(proto, buf, expected):
     assert codec_by_name("cid").to_string(proto, buf) == expected
+
+
+def test_string_iter_unix_path():
+    from multiaddr.transforms import string_iter
+
+    parts = list(string_iter("/unix/var/run/docker.sock"))
+    assert len(parts) == 1
+    proto, _, value = parts[0]
+    assert proto.name == "unix"
+    assert value == "var/run/docker.sock"


### PR DESCRIPTION
Fixes #112

## Description
This pull request ensures that `string_iter()` in `multiaddr/transforms.py` has the same handling for path protocols (e.g., `unix`) as `Multiaddr._from_string()`. Previously, it was only taking a single chunk of string as the protocol's value, which fails for paths containing multiple slashes (e.g., `/unix/var/run/docker.sock`). This update explicitly checks if a codec is a path (`codec.IS_PATH`) and if so, consumes all remaining components joined by slashes.

## Changes
- Updated `string_iter()` in `multiaddr/transforms.py` to use `getattr(codec, \IS_PATH\, False)` to check for path codecs and consume remaining parts appropriately.
- Added `test_string_iter_unix_path()` in `tests/test_transforms.py` to explicitly verify the behavior of parsing a `/unix/` path string.
- Added a towncrier newsfragment `newsfragments/112.bugfix`.