### PR TITLE
feat: export commonly used symbols from __init__

### DIFF
--- a/multiaddr/__init__.py
+++ b/multiaddr/__init__.py
@@ -1,5 +1,71 @@
-from .multiaddr import Multiaddr  # NOQA
+from .exceptions import (
+    BinaryParseError,
+    ParseError,
+    ProtocolExistsError,
+    ProtocolLookupError,
+    ProtocolNotFoundError,
+    ProtocolRegistryLocked,
+    RecursionLimitError,
+    ResolutionError,
+    StringParseError,
+)
+from .multiaddr import Multiaddr
+from .protocols import (
+    P_DNS,
+    P_DNS4,
+    P_DNS6,
+    P_DNSADDR,
+    P_IP4,
+    P_IP6,
+    P_P2P,
+    P_TCP,
+    P_UDP,
+    PROTOCOLS,
+    REGISTRY,
+    Protocol,
+    protocol_with_code,
+    protocol_with_name,
+)
+from .utils import (
+    get_multiaddr_options,
+    get_network_addrs,
+    get_thin_waist_addresses,
+    is_link_local_ip,
+    is_wildcard,
+)
 
 __author__ = "Steven Buss"
 __email__ = "steven.buss@gmail.com"
 __version__ = "0.2.0"
+
+__all__ = [
+    "PROTOCOLS",
+    "P_DNS",
+    "P_DNS4",
+    "P_DNS6",
+    "P_DNSADDR",
+    "P_IP4",
+    "P_IP6",
+    "P_P2P",
+    "P_TCP",
+    "P_UDP",
+    "REGISTRY",
+    "BinaryParseError",
+    "Multiaddr",
+    "ParseError",
+    "Protocol",
+    "ProtocolExistsError",
+    "ProtocolLookupError",
+    "ProtocolNotFoundError",
+    "ProtocolRegistryLocked",
+    "RecursionLimitError",
+    "ResolutionError",
+    "StringParseError",
+    "get_multiaddr_options",
+    "get_network_addrs",
+    "get_thin_waist_addresses",
+    "is_link_local_ip",
+    "is_wildcard",
+    "protocol_with_code",
+    "protocol_with_name",
+]

--- a/newsfragments/121.feature
+++ b/newsfragments/121.feature
@@ -1,0 +1,1 @@
+Export commonly used symbols directly from `multiaddr/__init__.py`.


### PR DESCRIPTION
Fixes #121

## Description
This PR expands `multiaddr/__init__.py` to directly export commonly used symbols from `protocols`, `exceptions`, and `utils`. Previously, only `Multiaddr` was exported, requiring users to explicitly import internal submodules to access basic things like protocol constants or parse errors.

## Changes
- Exported various protocol constants, the registry, and `Protocol` from `multiaddr.protocols`
- Exported parsing and lookup exceptions from `multiaddr.exceptions`
- Exported utility functions from `multiaddr.utils`
- Defined `__all__` in `__init__.py` with these exports
- Added a newsfragment for towncrier