### PR TITLE
Enable PR branch update suggestions (fixes #131)

### DIFF
--- a/newsfragments/131.internal.rst
+++ b/newsfragments/131.internal.rst
@@ -1,0 +1,3 @@
+Enabled GitHub's "Always suggest updating pull request branches" setting on
+the repository, matching libp2p/py-libp2p. Contributors may see Update branch
+or Update with rebase when a pull request is behind master and merges cleanly.


### PR DESCRIPTION
## Summary
- Adds newsfragment for enabling GitHub **Always suggest updating pull request branches** (`allow_update_branch`), aligning with libp2p/py-libp2p.
- Fixes #131.

## Maintainer action (repo setting, not in git)
After review or on merge, confirm the setting is on:

```bash
gh api repos/multiformats/py-multiaddr -X PATCH -f allow_update_branch=true
gh api repos/multiformats/py-multiaddr --jq '{allow_update_branch, default_branch}'
```

## Test plan
- [x] `make pr`
- [x] `make validate-newsfragments`
- [ ] `allow_update_branch` is `true` on the repo
- [ ] (Optional) On a PR behind `master` with a clean merge, **Update branch** is visible when permitted


Made with [Cursor](https://cursor.com)